### PR TITLE
fix: restore UART direct read for initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 examples/basicSensor/debug.cfg
 examples/basicSensor/debug.svd
 examples/basicSensor/debug_custom.json
+*.code-workspace

--- a/examples/basicSensor/basicSensor.ino
+++ b/examples/basicSensor/basicSensor.ino
@@ -71,6 +71,8 @@ void setup(void)
   MONITOR_SERIAL.print(F("Connect LD2410 radar RX to GPIO:"));
   MONITOR_SERIAL.println(RADAR_TX_PIN);
   MONITOR_SERIAL.print(F("LD2410 radar sensor initialising: "));
+
+  
   if(radar.begin(RADAR_SERIAL))
   {
     MONITOR_SERIAL.println(F("OK"));

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -95,7 +95,8 @@ class ld2410	{
         bool find_frame_start();
         bool check_frame_end_();
 		
-		bool read_frame_();												//Try to read a frame from the UART
+		bool read_frame_();		
+		bool read_frame_no_buffer_();										//Try to read a frame from the UART
 		bool parse_data_frame_();										//Is the current data frame valid?
 		bool parse_command_frame_();									//Is the current command frame valid?
 		void print_frame_();											//Print the frame for debugging


### PR DESCRIPTION
- Add direct UART read function `read_frame_no_buffer_` for initialization
- Use direct read during begin() for firmware version check
- Keep circular buffer functionality for normal operation
- Fix issue #32  where begin() always returns false

This change restores the reliable initialization behavior from v0.1.3 while maintaining the benefits of circular buffer operation introduced in v0.1.4.