### PR TITLE
fix(ld2410): correct byte offsets for target distances

### DIFF
--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -361,7 +361,7 @@ bool ld2410::parse_data_frame_() {
         target_type_ = radar_data_frame_[8];
 
         // Estrai distanze e energie dei bersagli
-        stationary_target_distance_ = *(uint16_t *)(&radar_data_frame_[12]);
+        stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[12]);
         moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
         stationary_target_energy_ = radar_data_frame_[14];
         moving_target_energy_ = radar_data_frame_[11];

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -361,8 +361,8 @@ bool ld2410::parse_data_frame_() {
         target_type_ = radar_data_frame_[8];
 
         // Estrai distanze e energie dei bersagli
-        stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
-        moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[15]);
+        stationary_target_distance_ = *(uint16_t *)(&radar_data_frame_[12]);
+        moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
         stationary_target_energy_ = radar_data_frame_[14];
         moving_target_energy_ = radar_data_frame_[11];
 


### PR DESCRIPTION
Previously, the code assigned moving_target_distance_ and stationary_target_distance_ using incorrect byte offsets:
    stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
    moving_target_distance_     = *(uint16_t*)(&radar_data_frame_[15]);
This incorrectly mapped the moving target distance to the detection distance field, and stationary to moving.

This commit corrects the offsets to align with the LD2410 datasheet:
    moving_target_distance_     = *(uint16_t*)(&radar_data_frame_[9]);    // bytes 9–10: moving target
    stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[12]);   // bytes 12–13: stationary target

Verified against the official protocol documentation. Now all fields match their intended data sources.