### PR TITLE
Upstream merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 *.out
 *.app
 
+# Tests build artifacts
+tests/test_parser
+
 # Arduino
 .development
 examples/basicSensor/debug.cfg

--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ The LD2410, as sold for configuration with the common breakout boards shown abov
 
 The modules also provide an 'active high' output on the 'OUT' pin which can be used to signal presence, based off the settings configured. Once the modules are configured it is not necessary to use their UART, but it provides much more information.
 
-## Updates in this fork (`adapt-to-it/ld2410`)
-
-This is a maintained fork of [`ncmreynolds/ld2410`](https://github.com/ncmreynolds/ld2410). The following pull requests have been merged into `main`:
-
-- [**#1 — Cross-platform task fixes + protocol-aligned engineering frame parser**](https://github.com/adapt-to-it/ld2410/pull/1) — removes ESP32-only constructs from the polling path so AVR/ESP8266 builds compile cleanly again, fixes engineering-frame byte offsets per the [HLK-LD2410C protocol spec](docs/HLK-LD2410C_protocol.md), protects shared sensor state with `portMUX_TYPE` on ESP32, and introduces the optional `autoReadTask()` background-reader API on ESP32.
-- [**#2 — Native host-side parser unit tests**](https://github.com/adapt-to-it/ld2410/pull/2) — `g++` build of the parser against fixture frames from the protocol doc, runnable with `bash tests/run.sh`.
-- [**#3 — Task-safe `request*`/`set*` commands**](https://github.com/adapt-to-it/ld2410/pull/3) — the command path now coordinates with `autoReadTask` via a sequence-number ACK helper (`wait_for_ack_`), so blocking commands can be issued concurrently with the background reader without UART races. Adds the `isAutoReadTaskRunning()` getter.
-
 ## Connections
 
 The module must be powered by 5V or higher, but does 3.3v I/O, please consider this when working with the module.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ The LD2410, as sold for configuration with the common breakout boards shown abov
 
 The modules also provide an 'active high' output on the 'OUT' pin which can be used to signal presence, based off the settings configured. Once the modules are configured it is not necessary to use their UART, but it provides much more information.
 
+## Updates in this fork (`adapt-to-it/ld2410`)
+
+This is a maintained fork of [`ncmreynolds/ld2410`](https://github.com/ncmreynolds/ld2410). The following pull requests have been merged into `main`:
+
+- [**#1 — Cross-platform task fixes + protocol-aligned engineering frame parser**](https://github.com/adapt-to-it/ld2410/pull/1) — removes ESP32-only constructs from the polling path so AVR/ESP8266 builds compile cleanly again, fixes engineering-frame byte offsets per the [HLK-LD2410C protocol spec](docs/HLK-LD2410C_protocol.md), protects shared sensor state with `portMUX_TYPE` on ESP32, and introduces the optional `autoReadTask()` background-reader API on ESP32.
+- [**#2 — Native host-side parser unit tests**](https://github.com/adapt-to-it/ld2410/pull/2) — `g++` build of the parser against fixture frames from the protocol doc, runnable with `bash tests/run.sh`.
+- [**#3 — Task-safe `request*`/`set*` commands**](https://github.com/adapt-to-it/ld2410/pull/3) — the command path now coordinates with `autoReadTask` via a sequence-number ACK helper (`wait_for_ack_`), so blocking commands can be issued concurrently with the background reader without UART races. Adds the `isAutoReadTaskRunning()` getter.
+
 ## Connections
 
 The module must be powered by 5V or higher, but does 3.3v I/O, please consider this when working with the module.

--- a/docs/HLK-LD2410C_protocol.md
+++ b/docs/HLK-LD2410C_protocol.md
@@ -1,0 +1,751 @@
+# HLK-LD2410C
+## Human presence sensing module — serial communication protocol
+
+**Manufacturer:** Shenzhen Hi-Link Electronic Co., Ltd
+**Version:** V1.00
+**Modify date:** 2022-11-7
+**Copyright:** © Shenzhen Hi-Link Electronic Co., Ltd
+
+---
+
+## Catalog
+
+1. [Communication interface introduction](#1-communication-interface-introduction)
+   - 1.1 [Pin definition](#11-pin-definition)
+   - 1.2 [Use and configuration](#12-use-and-configuration)
+     - 1.2.1 [Typical application circuits](#121-typical-application-circuits)
+     - 1.2.2 [The role of configuration parameters](#122-the-role-of-configuration-parameters)
+     - 1.2.3 [Visual configuration tool description](#123-visual-configuration-tool-description)
+2. [Communication protocols](#2-communication-protocols)
+   - 2.1 [Protocol format](#21-protocol-format)
+     - 2.1.1 [Protocol data format](#211-protocol-data-format)
+     - 2.1.2 [Command protocol frame format](#212-command-protocol-frame-format)
+   - 2.2 [Send command with ACK](#22-send-command-with-ack)
+     - 2.2.1 [Enabling configuration commands](#221-enabling-configuration-commands)
+     - 2.2.2 [End configuration command](#222-end-configuration-command)
+     - 2.2.3 [Maximum distance gate and unoccupied duration parameters configuration command](#223-maximum-distance-gate-and-unoccupied-duration-parameters-configuration-command)
+     - 2.2.4 [Read parameter command](#224-read-parameter-command)
+     - 2.2.5 [Enabling engineering mode command](#225-enabling-engineering-mode-command)
+     - 2.2.6 [Close project mode command](#226-close-project-mode-command)
+     - 2.2.7 [Distance gate sensitivity configuration command](#227-distance-gate-sensitivity-configuration-command)
+     - 2.2.8 [Read firmware version command](#228-read-firmware-version-command)
+     - 2.2.9 [Set serial port baud rate](#229-set-serial-port-baud-rate)
+     - 2.2.10 [Restore factory settings](#2210-restore-factory-settings)
+     - 2.2.11 [Restart module](#2211-restart-module)
+     - 2.2.12 [Bluetooth settings](#2212-bluetooth-settings)
+     - 2.2.13 [Get mac address](#2213-get-mac-address)
+     - 2.2.14 [Obtaining bluetooth permissions](#2214-obtaining-bluetooth-permissions)
+     - 2.2.15 [Setting Bluetooth password](#2215-setting-bluetooth-password)
+     - 2.2.16 [Distance resolution setting](#2216-distance-resolution-setting)
+     - 2.2.17 [Query distance resolution setting](#2217-query-distance-resolution-setting)
+   - 2.3 [Radar data output protocol](#23-radar-data-output-protocol)
+     - 2.3.1 [Reported data frame format](#231-reported-data-frame-format)
+     - 2.3.2 [Target data composition](#232-target-data-composition)
+   - 2.4 [Radar command configuration method](#24-radar-command-configuration-method)
+     - 2.4.1 [Radar command configuration steps](#241-radar-command-configuration-steps)
+3. [Revision records](#3-revision-records)
+4. [Technical support and contact information](#4-technical-support-and-contact-information)
+
+---
+
+## Chart Index
+
+- Table 1 — Pin definition table
+- Table 2 — Send command protocol frame format
+- Table 3 — Data format in the sending frame
+- Table 4 — ACK command protocol frame format
+- Table 5 — ACK intra-frame data format
+- Table 6 — Serial port baud rate selection
+- Table 7 — Factory default configuration values
+- Table 8 — Distance resolution selection
+- Table 9 — Reported data frame format
+- Table 10 — Intra-frame data frame format
+- Table 11 — Data type description
+- Table 12 — Target basic information data composition
+- Table 13 — Target state value description
+- Table 14 — Engineering model target data composition
+
+---
+
+# 1 Communication interface introduction
+
+## 1.1 Pin definition
+
+**Table 1 — Pin definition table**
+
+| Pin | Symbol  | Name                | Function                                                                       |
+|-----|---------|---------------------|--------------------------------------------------------------------------------|
+| 1   | UART_Tx | UART Tx             | UART Tx pin                                                                    |
+| 2   | UART_Rx | UART Rx             | UART Rx pin                                                                    |
+| 3   | OUT     | Target state output | Human presence detected: output high level / No human presence: output low level |
+| 4   | GND     | Power Ground        | Power Ground                                                                   |
+| 5   | VCC     | Power input         | Power input 5~12V (Suggest: 5V)                                                |
+
+## 1.2 Use and configuration
+
+### 1.2.1 Typical application circuits
+
+LD2410C module directly through an IO pin output the detected target state (someone high, no one low), but also through the serial port in accordance with the prescribed protocol for the output of the detection results data. The serial output data contains the target state and distance auxiliary information, etc., the user can be used flexibly according to specific application scenarios.
+
+The module power supply voltage is 5V and the power supply capacity of the input power supply is required to be greater than 200 mA.
+
+The module IO output level is 3.3 V. The default baud rate of the serial port is 256000, with 1 stop bit and no parity bit.
+
+### 1.2.2 The role of configuration parameters
+
+Users can modify the configuration parameters to the module through the serial port of LD2410C to adapt to different application requirements.
+
+The configurable radar detection parameters include the following:
+
+**● The farthest detection distance**
+
+Set the maximum detectable distance, only human targets that appear within this maximum distance will be detected and the result will be output.
+
+Set up in units of distance gate, each distance gate is 0.75 m.
+
+Including motion detection of the farthest distance gate and stationary detection of the farthest distance gate, can be set in the range of 1 to 8. For example, set the farthest distance gate to 2: only the presence of the human body within 1.5 m will be effectively detected and output the results.
+
+**● Sensitivity**
+
+The presence of a target is determined when the detected target energy value (range 0 to 100) is greater than the sensitivity value, otherwise it is ignored.
+
+Sensitivity value can be set in the range of 0 to 100. Each distance gate can be set independently of the sensitivity, that is, the detection of different distances within the range of precise adjustment, local precision detection or filtering of specific areas of interference sources.
+
+In addition, if the sensitivity of a distance gate is set to 100, the effect of not identifying the target under this distance gate can be achieved. For example, the sensitivity of distance gate 3 and distance gate 4 is set to 20, and the sensitivity of all other distance gates is set to 100, then only the human body within 2.25 to 3.75 m of the distance module can be achieved to detect.
+
+**● No-one duration**
+
+Radar in the output from occupied to unoccupied results, will continue to report a period of time on the occupied. If the radar test range in this time period continued unoccupied, the radar reported unoccupied; if the radar detects someone in this time period, then refreshed this time, unit seconds. Equivalent to no one delay time: after the person left, keep no one more than this duration before the output status for no one.
+
+### 1.2.3 Visual configuration tool description
+
+In order to facilitate users to quickly and efficiently test and configure the module, the PC terminal configuration tool is provided. Users can use this tool software to connect to the serial port of the module, read and configure the parameters of the module, and also receive the detection result data reported by the module, and make real-time visualization display, which is greatly convenient for users.
+
+**Usage of the Uplink tool:**
+
+1. Properly connect the module serial port with the USB-to-serial port tool.
+2. Select the corresponding serial port number in the upper computer tool, set the baud rate 256000, select the engineering mode and click "connect the device".
+3. After successful connection, click the "start" button; the right graphical interface will display the detection results and data.
+4. After connection, when the start button is not clicked, or click stop after starting, the mode parameter information can be read or set.
+
+**Note:** Parameters cannot be read and configured after clicking Start, and can only be configured after stopping.
+
+In the visualization tool:
+
+- The ball is the target status output indication: **red** means there is a moving target; **purple** means there is a stationary target; **green** means no one.
+- **Green line:** the set sensitivity.
+- **Blue line:** moving target energy value on each distance gate.
+- **Red line:** static target energy value on each range gate.
+
+---
+
+# 2 Communication protocols
+
+The LD2410C communicates with the outside world through a serial port (TTL level). Data output and parameter configuration commands of the radar are carried out under this protocol. The default baud rate of the radar serial port is 256000, 1 stop bit, no parity bit.
+
+## 2.1 Protocol format
+
+### 2.1.1 Protocol data format
+
+The LD2410C uses **little-endian** format for serial data communication, and all data in the following tables are in hexadecimal.
+
+### 2.1.2 Command protocol frame format
+
+The format of the protocol-defined radar configuration commands and ACK commands are shown in Table 2 to Table 5.
+
+**Table 2 — Send command protocol frame format**
+
+| Frame header | Intra-frame data length | Intra-frame data | End of frame |
+|--------------|-------------------------|------------------|--------------|
+| FD FC FB FA  | 2 bytes                 | See Table 3      | 04 03 02 01  |
+
+**Table 3 — Data format in the sending frame**
+
+| Command word (2 bytes) | Command value (N bytes) |
+|------------------------|-------------------------|
+
+**Table 4 — ACK command protocol frame format**
+
+| Frame header | Intra-frame data length | Intra-frame data | End of frame |
+|--------------|-------------------------|------------------|--------------|
+| FD FC FB FA  | 2 bytes                 | See Table 5      | 04 03 02 01  |
+
+**Table 5 — ACK intra-frame data format**
+
+| Send command word \| 0x0100 (2 bytes) | Return value (N bytes) |
+|----------------------------------------|------------------------|
+
+## 2.2 Send command with ACK
+
+### 2.2.1 Enabling configuration commands
+
+Any other commands issued to the radar must be executed after this command is issued, otherwise they are invalid.
+
+- **Command word:** 0x00FF
+- **Command value:** 0x0001
+- **Return value:** 2 bytes ACK status (0 success, 1 failure) + 2 bytes protocol version (0x0001) + 2 bytes buffer size (0x0040)
+
+**Send data:**
+
+| FD FC FB FA | 04 00 | FF 00 | 01 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 08 00 | FF 01 | 00 00 | 01 00 | 40 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------|-------|-------------|
+
+### 2.2.2 End configuration command
+
+End the configuration command and the radar resumes working mode after execution. If you need to issue other commands again, you need to send the enable configuration command first.
+
+- **Command word:** 0x00FE
+- **Command value:** None
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | FE 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | FE 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.3 Maximum distance gate and unoccupied duration parameters configuration command
+
+This command sets the radar maximum detection distance gate (motion & stationary) (configuration range 2~8), and the unmanned duration parameter (configuration range 0~65535 seconds). Please refer to the specific parameter word table below. This configuration value is not lost when power is dropped.
+
+- **Command word:** 0x0060
+- **Command value:** 2-byte maximum motion distance gate word + 4-byte maximum motion distance gate parameter + 2-byte maximum standstill distance gate word + 4-byte maximum standstill distance gate parameter + 2-byte unoccupied duration word + 4-byte unoccupied duration parameter
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**0x0060 protocol parameter word:**
+
+| Parameter name                 | Parameter word |
+|--------------------------------|----------------|
+| Maximum movement distance door | 0x0000         |
+| Maximum resting distance door  | 0x0001         |
+| No one duration                | 0x0002         |
+
+**Send data:** maximum distance door 8 (motion & stationary), no one duration 5 seconds
+
+| FD FC FB FA | 14 00 | 60 00 | 00 00 | 08 00 00 00 | 01 00 | 08 00 00 00 | 02 00 | 05 00 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|-------|-------------|-------|-------------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | 60 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.4 Read parameter command
+
+This command allows you to read the current configuration parameters of the radar.
+
+- **Command word:** 0x0061
+- **Command value:** None
+- **Return value:** 2 bytes ACK status (0 success, 1 failure) + header (0xAA) + max distance gate N (0x08) + configure max motion distance gate + configure max rest distance gate + distance gate 0 motion sensitivity (1 byte) + ... + distance gate N motion sensitivity (1 byte) + distance gate 0 rest sensitivity (1 byte) + ... + distance gate N stationary sensitivity (1 byte) + unoccupied duration (2 bytes)
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | 61 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK** (success, maximum distance gate 8, configured motion distance gate 8, stationary distance gate 8, 0~8 motion sensitivity 20, 0~8 stationary sensitivity 25, unoccupied duration 5 seconds):
+
+| Bytes      | Value           |
+|------------|-----------------|
+| Byte 1–4   | FD FC FB FA     |
+| Byte 5, 6  | 1C 00           |
+| Byte 7, 8  | 61 01           |
+| Byte 9, 10 | 00 00           |
+| Byte 11    | AA              |
+| Byte 12    | 08              |
+| Byte 13    | 08              |
+| Byte 14    | 08              |
+| Byte 15    | 14              |
+| Byte 16    | 14              |
+| Byte 17    | 14              |
+| Byte 18    | 14              |
+| Byte 19    | 14              |
+| Byte 20    | 14              |
+| Byte 21    | 14              |
+| Byte 22    | 14              |
+| Byte 23    | 14              |
+| Byte 24    | 19              |
+| Byte 25    | 19              |
+| Byte 26    | 19              |
+| Byte 27    | 19              |
+| Byte 28    | 19              |
+| Byte 29    | 19              |
+| Byte 30    | 19              |
+| Byte 31    | 19              |
+| Byte 32    | 19              |
+| Byte 33, 34| 05 00           |
+| Byte 35–38 | 04 03 02 01     |
+
+### 2.2.5 Enabling engineering mode command
+
+This command opens the radar engineering mode. When the engineering mode is turned on, each distance gate energy value will be added to the radar report data, please refer to [2.3.2 Target Data Composition](#232-target-data-composition) for detailed format. Engineering mode is off by default after the module is powered on, this configuration value is lost when power is lost.
+
+- **Command word:** 0x0062
+- **Command value:** None
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | 62 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | 62 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.6 Close project mode command
+
+This command turns off the radar engineering mode. After it is turned off, please refer to [2.3.2 Target Data Composition](#232-target-data-composition) for the format of radar report data.
+
+- **Command word:** 0x0063
+- **Command value:** None
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | 63 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | 63 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.7 Distance gate sensitivity configuration command
+
+This command configures the sensitivity of the distance gate, and the configured value is not lost when power is dropped. It supports both configuring each distance gate individually and configuring all distance gates to a uniform value at the same time. If setting all distance gates sensitivity to the same value at the same time, the distance gate value needs to be set to 0xFFFF.
+
+- **Command word:** 0x0064
+- **Command value:** 2-byte distance gate word + 4-byte distance gate value + 2-byte motion sensitivity word + 4-byte motion sensitivity value + 2-byte standstill sensitivity word + 4-byte standstill sensitivity value
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**0x0064 protocol parameter word:**
+
+| Parameter name           | Parameter word |
+|--------------------------|----------------|
+| Distance door            | 0x0000         |
+| Movement sensitivity word| 0x0001         |
+| Static Sensitivity Word  | 0x0002         |
+
+**Send data:** configured distance gate 3, motion sensitivity 40, stationary sensitivity 40
+
+| FD FC FB FA | 14 00 | 64 00 | 00 00 | 03 00 00 00 | 01 00 | 28 00 00 00 | 02 00 | 28 00 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|-------|-------------|-------|-------------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | 64 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Send data:** Configure motion sensitivity 40 for all distance doors, rest sensitivity 40
+
+| FD FC FB FA | 14 00 | 64 00 | 00 00 | FF FF 00 00 | 01 00 | 28 00 00 00 | 02 00 | 28 00 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|-------|-------------|-------|-------------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | 64 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.8 Read firmware version command
+
+This command reads the radar firmware version information.
+
+- **Command word:** 0x00A0
+- **Command value:** None
+- **Return value:** 2 bytes ACK status (0 success, 1 failure) + 2 bytes firmware type (0x0001) + 2 bytes major version number + 4 bytes minor version number
+
+> Note: the ACK example below has known transcription errors versus the protocol structure (Tables 4-5). Per the protocol, intra-frame data must start with the *command word ACK* (`sent_command | 0x0100`, i.e. bytes `A0 01` LE for command 0x00A0), which the example omits and the description above also fails to mention. The structurally correct positional layout (1-indexed bytes from frame start) is:
+>
+> | Bytes  | Field                              | Notes                                                  |
+> |--------|------------------------------------|--------------------------------------------------------|
+> | 1-4    | Frame header                       | `FD FC FB FA`                                          |
+> | 5-6    | Intra-frame data length            | `0C 00` = 12                                           |
+> | 7-8    | Command word ACK                   | `A0 01` LE — **missing in the example below**          |
+> | 9-10   | ACK status                         | `00 00` = success                                      |
+> | 11-12  | Firmware type                      | `01 00` LE = 0x0001 — example shows `00 01` (typo)     |
+> | 13     | Minor version                      | e.g. `07` = 0x07                                       |
+> | 14     | Major version                      | e.g. `01` = 0x01                                       |
+> | 15-18  | Bugfix version (LE uint32)         | e.g. `16 15 09 22` → 0x22091516                        |
+> | 19-22  | End of frame                       | `04 03 02 01`                                          |
+>
+> Implementations should anchor on the command word ACK at bytes 7-8 (offset 6-7 in 0-indexed buffers) — *not* on the example's leading `00 00`. With the example bytes, the version parses as `V1.07` plus bugfix `0x22091516`; the original Hi-Link version string `V1.07.22091615` has the last four hex digits transposed.
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | A0 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 0C 00 | 00 00 | 00 01 | 07 01 | 16 15 09 22 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------|-------------|-------------|
+
+The corresponding version number is V1.07.22091615.
+
+### 2.2.9 Set serial port baud rate
+
+This command is used to set the baud rate of the serial port of the module. The configured value is not lost when power is lost, and the configured value takes effect after restarting the module.
+
+- **Command word:** 0x00A1
+- **Command value:** 2-byte baud rate selection index
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Table 6 — Serial port baud rate selection**
+
+| Baud rate selection index value | Baud rate |
+|---------------------------------|-----------|
+| 0x0001                          | 9600      |
+| 0x0002                          | 19200     |
+| 0x0003                          | 38400     |
+| 0x0004                          | 57600     |
+| 0x0005                          | 115200    |
+| 0x0006                          | 230400    |
+| 0x0007                          | 256000    |
+| 0x0008                          | 460800    |
+
+The factory default value is 0x0007, which is 256000.
+
+**Send data:**
+
+| FD FC FB FA | 04 00 | A1 00 | 07 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | A1 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.10 Restore factory settings
+
+This command is used to restore all the configuration values to their non-factory values, which take effect after rebooting the module.
+
+- **Command word:** 0x00A2
+- **Command value:** None
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | A2 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | A2 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+The factory default configuration values are as follows:
+
+**Table 7 — Factory default configuration values**
+
+| Configuration items            | Default value |
+|--------------------------------|---------------|
+| Maximum movement distance door | 8             |
+| Maximum resting distance door  | 8             |
+| No one duration                | 5             |
+| Serial port baud rate          | 256000        |
+
+| Configuration items                   | Default value     | Configuration items                   | Default value      |
+|---------------------------------------|-------------------|---------------------------------------|--------------------|
+| Motion sensitivity of distance gate 0 | 50                | Static sensitivity of distance gate 0 | – (not settable)   |
+| Motion sensitivity of distance gate 1 | 50                | Static sensitivity of distance gate 1 | – (not settable)   |
+| Motion sensitivity of distance gate 2 | 40                | Static sensitivity of distance gate 2 | 40                 |
+| Motion sensitivity of distance gate 3 | 30                | Static sensitivity of distance gate 3 | 40                 |
+| Motion sensitivity of distance gate 4 | 20                | Static sensitivity of distance gate 4 | 30                 |
+| Motion sensitivity of distance gate 5 | 15                | Static sensitivity of distance gate 5 | 30                 |
+| Motion sensitivity of distance gate 6 | 15                | Static sensitivity of distance gate 6 | 20                 |
+| Motion sensitivity of distance gate 7 | 15                | Static sensitivity of distance gate 7 | 20                 |
+| Motion sensitivity of distance gate 8 | 15                | Static sensitivity of distance gate 8 | 20                 |
+
+### 2.2.11 Restart module
+
+The module receives this command and will automatically restart after the answer is sent.
+
+- **Command word:** 0x00A3
+- **Command value:** None
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | A3 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | A3 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.12 Bluetooth settings
+
+This command is used to control the Bluetooth on or off. The Bluetooth function of the module is on by default.
+
+After receiving this command, a reboot is required for the function to take effect.
+
+- **Command word:** 0x00A4
+- **Command value:** 0x0100 Turn on bluetooth / 0x0000 Turn off bluetooth
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:** (Turn on bluetooth)
+
+| FD FC FB FA | 04 00 | A4 00 | 01 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | A4 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.13 Get mac address
+
+This command is used to query the MAC address.
+
+- **Command word:** 0x00A5
+- **Command value:** 0x0001
+- **Return value:** 2-byte ACK status (0 success, 1 failure) + 1 byte fixed type (0x00) + 3 bytes MAC address (address is in big terminal order)
+
+> Note: the documented payload returns 6 bytes of MAC address (the example below shows a 6-byte address).
+
+**Send data:**
+
+| FD FC FB FA | 04 00 | A5 00 | 01 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 0A 00 | A5 01 | 00 00 | 8F 27 | 2E B8 | 0F 65 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------|-------|-------|-------------|
+
+The MAC address queried is: `8F 27 2E B8 0F 65`.
+
+### 2.2.14 Obtaining bluetooth permissions
+
+This command is used to get the Bluetooth permission, and you can use the APP to get the device information and debugging parameters through Bluetooth after successful acquisition.
+
+- **Command word:** 0x00A8
+- **Command value:** 6 bytes of password value (every 2 bytes in little-endian order)
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+The default password is `"HiLink"`, then the corresponding value is 0x4869 (Hi) 0x4c69 (Li) 0x6e6b (nk).
+
+**Send data:**
+
+| FD FC FB FA | 08 00 | A8 00 | 48 69 | 4c 69 | 6e 6b | 48 69 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | A8 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Note:** This response only answers to Bluetooth, not to the serial port.
+
+### 2.2.15 Setting Bluetooth password
+
+This command is used to set the password for Bluetooth control.
+
+- **Command word:** 0x00A9
+- **Command value:** 6 bytes of password value (each byte is in little-endian order)
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Send data:**
+
+| FD FC FB FA | 08 00 | A9 00 | 48 69 | 4c 69 | 6e 6b | 48 69 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | A9 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.16 Distance resolution setting
+
+Set the distance resolution of the module, that is how far away each distance gate represents. The configuration value is not lost when power is lost, and the configuration value takes effect after restarting the module.
+
+Can be configured to 0.75 m or 0.2 m per distance gate; the maximum number of distance gates supported is 8.
+
+- **Command word:** 0x00AA
+- **Command value:** 2-byte distance resolution selection index
+- **Return value:** 2-byte ACK status (0 success, 1 failure)
+
+**Table 8 — Distance resolution selection**
+
+| Distance resolution selection index value | Distance resolution (distance represented by each distance gate) |
+|-------------------------------------------|------------------------------------------------------------------|
+| 0x0000                                    | 0.75 m                                                           |
+| 0x0001                                    | 0.2 m                                                            |
+
+Factory default value is 0x0000, which is 0.75 m.
+
+> Note: the original document text states "Factory default value is 0x0001, which is 0.75m", which is inconsistent with Table 8. Per the table mapping, 0x0000 corresponds to 0.75 m.
+
+**Send data:**
+
+| FD FC FB FA | 04 00 | AA 00 | 01 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 04 00 | AA 01 | 00 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------------|
+
+### 2.2.17 Query distance resolution setting
+
+Query the module's current distance resolution setting, i.e. how far away each distance gate represents.
+
+- **Command word:** 0x00AB
+- **Command value:** None
+- **Return value:** 2-byte ACK status (0 success, 1 failure) + 2-byte distance resolution selection index
+
+Return value definition is the same as Table 8 — Distance resolution selection.
+
+**Send data:**
+
+| FD FC FB FA | 02 00 | AB 00 | 04 03 02 01 |
+|-------------|-------|-------|-------------|
+
+**Radar ACK (success):**
+
+| FD FC FB FA | 06 00 | AB 01 | 00 00 | 01 00 | 04 03 02 01 |
+|-------------|-------|-------|-------|-------|-------------|
+
+Represents the currently set distance resolution of 0.2 m.
+
+## 2.3 Radar data output protocol
+
+LD2410C outputs the radar detection result through serial port. The default output is basic target information, including target status, motion energy value, stationary energy value, motion distance, stationary distance and other information. If the radar is configured as engineering mode, the radar will additionally output each distance gate energy value (motion & stationary). Radar data is output in the prescribed frame format.
+
+### 2.3.1 Reported data frame format
+
+The format of the radar uplink message frames defined by the protocol is shown in Table 9 and Table 10. The definition of the report data type values in normal operation mode and engineering mode are shown in Table 11.
+
+**Table 9 — Reported data frame format**
+
+| Frame header | Length of data in the frame | Intra-frame data | End of frame |
+|--------------|-----------------------------|------------------|--------------|
+| F4 F3 F2 F1  | 2 bytes                     | See Table 10     | F8 F7 F6 F5  |
+
+**Table 10 — Intra-frame data frame format**
+
+| Data type             | Head | Target data            | Tail | Calibration |
+|-----------------------|------|------------------------|------|-------------|
+| 1 byte (See Table 11) | 0xAA | See Table 12, Table 14 | 0x55 | 0x00        |
+
+**Table 11 — Data type description**
+
+| Data type value | Description                   |
+|-----------------|-------------------------------|
+| 0x01            | Engineering mode data         |
+| 0x02            | Target basic information data |
+
+### 2.3.2 Target data composition
+
+The content of the target data reported by the radar will change depending on the operating mode of the radar. In normal operation mode, the radar outputs the basic information data of the target by default; when configured to engineering mode, the radar adds each distance gate energy value information after the basic information data of the target. Therefore, the basic information of the target will always be output in the radar report data, while the distance gate energy value information needs to be enabled by command to be output.
+
+The composition of the target data reported by the radar in normal operation mode is shown in Table 12, and the definition of the target state values is shown in Table 13. The composition of the target data frame in engineering mode is shown in Table 14, with additional data added to the data reported in normal operation mode.
+
+**Table 12 — Target basic information data composition**
+
+| Target Status         | Movement target distance (cm) | Exercise target energy value | Distance to stationary target (cm) | Stationary target energy value | Detection distance (cm) |
+|-----------------------|-------------------------------|------------------------------|-------------------------------------|--------------------------------|-------------------------|
+| 1 byte (See Table 13) | 2 bytes                       | 1 byte                       | 2 bytes                             | 1 byte                         | 2 bytes                 |
+
+**Table 13 — Target state value description**
+
+| Target state value | Description                  |
+|--------------------|------------------------------|
+| 0x00               | No target                    |
+| 0x01               | Movement target              |
+| 0x02               | Stationary target            |
+| 0x03               | Movement & Stationary target |
+
+**Table 14 — Engineering model target data composition**
+
+Add the following data after the target basic information data in Table 12:
+
+| ... | Maximum movement distance gate N | Maximum resting distance gate N | Movement distance gate 0 energy value | ... | Movement distance gate N energy value | Stationary distance gate 0 energy value | ... | Stationary distance gate N energy value | Retain data, store additional information |
+|-----|----------------------------------|---------------------------------|---------------------------------------|-----|---------------------------------------|------------------------------------------|-----|------------------------------------------|-------------------------------------------|
+| ... | 1 byte                           | 1 byte                          | 1 byte                                | ... | 1 byte                                | 1 byte                                   | ... | 1 byte                                   | M bytes                                   |
+
+**Example of reported data:**
+
+Data reported in normal operating mode:
+
+| Frame header | Length of data in frame | Intra-frame data                          | End of frame |
+|--------------|-------------------------|-------------------------------------------|--------------|
+| F4 F3 F2 F1  | 0D 00                   | 02 AA 02 51 00 00 00 00 3B 00 00 55 00    | F8 F7 F6 F5  |
+
+Data reported in engineering mode:
+
+| Frame header | Length of data in frame | Intra-frame data                                                                                                | End of frame |
+|--------------|-------------------------|-----------------------------------------------------------------------------------------------------------------|--------------|
+| F4 F3 F2 F1  | 23 00                   | 01 AA 03 1E 00 3C 00 00 39 00 00 08 08 3C 22 05 03 03 04 03 06 05 00 00 39 10 13 06 06 08 04 03 05 55 00         | F8 F7 F6 F5  |
+
+## 2.4 Radar command configuration method
+
+### 2.4.1 Radar command configuration steps
+
+The process of executing a configuration command by LD2410C radar consists of two parts: the upper computer "sends the command" and the radar "replies to the command ACK". If the radar does not reply with ACK or fails to reply with ACK, it means the radar fails to execute the configuration command.
+
+As mentioned earlier, before sending any other commands to the radar, the developer needs to send the "enable configuration" command and then send the configuration command within the specified time. After the commands are configured, the "end configuration" command is sent to inform the radar that the configuration is finished.
+
+For example, if you want to read the radar configuration parameters, first the host computer sends the "enable configuration" command; after receiving a successful radar ACK, then sends the "read parameters" command; after receiving a successful radar ACK, then sends the "end configuration" command; after receiving successful radar ACK, it indicates that the complete action of reading parameters is finished.
+
+The radar command configuration flow is as follows:
+
+```
+            ┌───────┐
+            │ Start │
+            └───┬───┘
+                │
+                ▼
+   Send the "enable command configuration" command
+                │
+                ▼
+        Received radar ACK success ── NO ──┐
+                │ YES                       │
+                ▼                           │
+   Send command (Multiple bars available)   │
+                │                           │
+                ▼                           │
+        Received radar ACK success ── NO ──┤
+                │ YES                       │
+                ▼                           │
+       Send "End command configuration"     │
+                │                           │
+                ▼                           │
+        Received radar ACK success ── NO ──┤
+                │ YES                       │
+                ▼                           ▼
+            ┌───────┐                    ┌───────┐
+            │  End  │ ◄──────────────────┤  End  │
+            └───────┘                    └───────┘
+```
+
+*Figure — Radar command configuration process*
+
+---
+
+# 3 Revision records
+
+| Date       | Version | Modify the content |
+|------------|---------|--------------------|
+| 2022-11-7  | 1.00    | Initial version    |
+
+---
+
+# 4 Technical support and contact information
+
+**Shenzhen Hi-Link Electronic Co., Ltd**
+
+- **Tel:** 0755-23152658 / 83575155
+- **Website:** [www.hlktech.com](http://www.hlktech.com)

--- a/examples/autoReadTask/autoReadTask.ino
+++ b/examples/autoReadTask/autoReadTask.ino
@@ -45,6 +45,7 @@
 
 ld2410 radar;
 uint32_t lastReading = 0;
+uint32_t lastConfigPoll = 0;
 
 void setup() {
   MONITOR_SERIAL.begin(115200);
@@ -106,6 +107,25 @@ void loop() {
       MONITOR_SERIAL.println();
     } else {
       MONITOR_SERIAL.println(F("No target"));
+    }
+  }
+
+  // Demonstration: every 30 s, while autoReadTask is busy reading frames,
+  // issue a configuration request. The library serialises the command on
+  // top of the running task — the task keeps draining UART, the command
+  // path waits on cmd_ack_seq_ for the matching ACK, and no race occurs.
+  if (radar.isAutoReadTaskRunning() && millis() - lastConfigPoll > 30000) {
+    lastConfigPoll = millis();
+    if (radar.requestCurrentConfiguration()) {
+      MONITOR_SERIAL.print(F("[config] max gates: "));
+      MONITOR_SERIAL.print(radar.max_moving_gate);
+      MONITOR_SERIAL.print(F(" moving / "));
+      MONITOR_SERIAL.print(radar.max_stationary_gate);
+      MONITOR_SERIAL.print(F(" stationary; idle "));
+      MONITOR_SERIAL.print(radar.sensor_idle_time);
+      MONITOR_SERIAL.println('s');
+    } else {
+      MONITOR_SERIAL.println(F("[config] requestCurrentConfiguration failed"));
     }
   }
 

--- a/examples/autoReadTask/autoReadTask.ino
+++ b/examples/autoReadTask/autoReadTask.ino
@@ -1,0 +1,114 @@
+/*
+ * Example sketch demonstrating the FreeRTOS task-based read pattern on ESP32.
+ *
+ * radar.autoReadTask() spawns a background task that drains the LD2410 UART
+ * continuously, so the main loop() never has to call radar.read() and never
+ * blocks on UART. The loop just consumes the latest cached values via the
+ * same getters used by basicSensor.
+ *
+ * ESP32 only — autoReadTask uses xTaskCreatePinnedToCore which is not
+ * available on ESP8266/AVR. For those boards use basicSensor.ino with the
+ * polling read() call.
+ *
+ * Pin map (same as basicSensor):
+ *   ESP32     -> LD2410 TX→GPIO 32, RX→GPIO 33
+ *   ESP32-S2  -> LD2410 TX→GPIO 9,  RX→GPIO 8
+ *   ESP32-C3  -> LD2410 TX→GPIO 4,  RX→GPIO 5
+ */
+
+#if !defined(ESP32)
+  #error "autoReadTask example requires ESP32. On ESP8266/AVR use basicSensor.ino instead."
+#endif
+
+#ifdef ESP_IDF_VERSION_MAJOR // IDF 4+
+  #if CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
+    #define RADAR_RX_PIN 32
+    #define RADAR_TX_PIN 33
+  #elif CONFIG_IDF_TARGET_ESP32S2
+    #define RADAR_RX_PIN 9
+    #define RADAR_TX_PIN 8
+  #elif CONFIG_IDF_TARGET_ESP32C3
+    #define RADAR_RX_PIN 4
+    #define RADAR_TX_PIN 5
+  #else
+    #error Target CONFIG_IDF_TARGET is not supported
+  #endif
+#else // ESP32 before IDF 4.0
+  #define RADAR_RX_PIN 32
+  #define RADAR_TX_PIN 33
+#endif
+
+#define MONITOR_SERIAL Serial
+#define RADAR_SERIAL Serial1
+
+#include <ld2410.h>
+
+ld2410 radar;
+uint32_t lastReading = 0;
+
+void setup() {
+  MONITOR_SERIAL.begin(115200);
+  // radar.debug(MONITOR_SERIAL);  // Uncomment for verbose library debug output
+  RADAR_SERIAL.begin(256000, SERIAL_8N1, RADAR_RX_PIN, RADAR_TX_PIN);
+  delay(500);
+
+  MONITOR_SERIAL.print(F("\nConnect LD2410 radar TX to GPIO:"));
+  MONITOR_SERIAL.println(RADAR_RX_PIN);
+  MONITOR_SERIAL.print(F("Connect LD2410 radar RX to GPIO:"));
+  MONITOR_SERIAL.println(RADAR_TX_PIN);
+  MONITOR_SERIAL.print(F("LD2410 radar sensor initialising: "));
+
+  if (!radar.begin(RADAR_SERIAL)) {
+    MONITOR_SERIAL.println(F("not connected"));
+    while (true) {
+      delay(1000);
+    }
+  }
+  MONITOR_SERIAL.println(F("OK"));
+  MONITOR_SERIAL.print(F("LD2410 firmware version: "));
+  MONITOR_SERIAL.print(radar.firmware_major_version);
+  MONITOR_SERIAL.print('.');
+  MONITOR_SERIAL.print(radar.firmware_minor_version);
+  MONITOR_SERIAL.print('.');
+  MONITOR_SERIAL.println(radar.firmware_bugfix_version, HEX);
+
+  // Spawn the background reader task. Defaults: stack=4096, priority=1,
+  // core=tskNO_AFFINITY (FreeRTOS picks a free core). Override the args if
+  // your sketch needs to pin to a specific core or change priority.
+  if (!radar.autoReadTask()) {
+    MONITOR_SERIAL.println(F("autoReadTask: failed to create FreeRTOS task"));
+    while (true) {
+      delay(1000);
+    }
+  }
+  MONITOR_SERIAL.println(F("autoReadTask: running in background"));
+}
+
+void loop() {
+  // Note: no radar.read() here. The background task is updating the fields
+  // for us — we just consume them.
+  if (radar.isConnected() && millis() - lastReading > 1000) {
+    lastReading = millis();
+    if (radar.presenceDetected()) {
+      if (radar.stationaryTargetDetected()) {
+        MONITOR_SERIAL.print(F("Stationary target: "));
+        MONITOR_SERIAL.print(radar.stationaryTargetDistance());
+        MONITOR_SERIAL.print(F("cm energy:"));
+        MONITOR_SERIAL.print(radar.stationaryTargetEnergy());
+        MONITOR_SERIAL.print(' ');
+      }
+      if (radar.movingTargetDetected()) {
+        MONITOR_SERIAL.print(F("Moving target: "));
+        MONITOR_SERIAL.print(radar.movingTargetDistance());
+        MONITOR_SERIAL.print(F("cm energy:"));
+        MONITOR_SERIAL.print(radar.movingTargetEnergy());
+      }
+      MONITOR_SERIAL.println();
+    } else {
+      MONITOR_SERIAL.println(F("No target"));
+    }
+  }
+
+  // To stop the background task (e.g. before re-init or shutdown):
+  //   radar.stopAutoReadTask();
+}

--- a/examples/basicSensor/basicSensor.ino
+++ b/examples/basicSensor/basicSensor.ino
@@ -10,9 +10,11 @@
  * 
  * The serial configuration for other boards will vary and you'll need to assign them yourself
  * 
- * There is no example for ESP8266 as it only has one usable UART and will not boot if the alternate UART pins are used for the radar.
- * 
- * For this sketch and other examples to be useful the board needs to have two usable UARTs.
+ * For ESP8266, see the basicSensorEsp8266 sibling example — it uses
+ * SoftwareSerial because the ESP8266's hardware UARTs cannot host both the
+ * radar and the serial monitor without colliding with strapping pins.
+ *
+ * For this sketch the board needs two usable hardware UARTs.
  * 
  */
 

--- a/examples/basicSensorEsp8266/basicSensorEsp8266.ino
+++ b/examples/basicSensorEsp8266/basicSensorEsp8266.ino
@@ -1,0 +1,89 @@
+/*
+ * Example sketch for the LD2410 on ESP8266.
+ *
+ * The ESP8266 only has 1.5 hardware UARTs (UART0 full-duplex on GPIO1/3,
+ * UART1 TX-only on GPIO2). Swapping UART0 to GPIO13/15 collides with
+ * strapping pin GPIO15 — the radar TX idles HIGH and would block boot.
+ * This sketch therefore uses SoftwareSerial for the radar and keeps UART0
+ * free for the serial monitor.
+ *
+ * Caveat: SoftwareSerial at 256000 baud (the radar's default) is at the
+ * upper edge of EspSoftwareSerial's reliable range. Occasional frame drops
+ * are expected, especially during dense detection bursts. For production
+ * use prefer a board with two hardware UARTs (ESP32, Leonardo).
+ *
+ * Wiring (NodeMCU / Wemos D1 mini):
+ *   LD2410 TX  -> ESP8266 GPIO14 (D5)
+ *   LD2410 RX  -> ESP8266 GPIO12 (D6)
+ *   LD2410 GND -> GND
+ *   LD2410 VCC -> 5V
+ *
+ * Avoid GPIO0 / GPIO2 / GPIO15 (strapping pins) and GPIO1 / GPIO3
+ * (UART0, used here by the serial monitor).
+ */
+
+#if !defined(ESP8266)
+  #error "basicSensorEsp8266 targets ESP8266 only. Use basicSensor for ESP32/AVR."
+#endif
+
+#include <ld2410.h>
+#include <SoftwareSerial.h>
+
+#define RADAR_RX_PIN 14
+#define RADAR_TX_PIN 12
+
+ld2410 radar;
+SoftwareSerial radarSerial(RADAR_RX_PIN, RADAR_TX_PIN);
+
+uint32_t lastReading = 0;
+
+void setup() {
+  Serial.begin(115200);
+  // radar.debug(Serial);  // Uncomment for verbose library debug output
+
+  radarSerial.begin(256000);
+  delay(500);
+
+  Serial.print(F("\nConnect LD2410 radar TX to GPIO:"));
+  Serial.println(RADAR_RX_PIN);
+  Serial.print(F("Connect LD2410 radar RX to GPIO:"));
+  Serial.println(RADAR_TX_PIN);
+  Serial.print(F("LD2410 radar sensor initialising: "));
+
+  if (radar.begin(radarSerial)) {
+    Serial.println(F("OK"));
+    Serial.print(F("LD2410 firmware version: "));
+    Serial.print(radar.firmware_major_version);
+    Serial.print('.');
+    Serial.print(radar.firmware_minor_version);
+    Serial.print('.');
+    Serial.println(radar.firmware_bugfix_version, HEX);
+  } else {
+    Serial.println(F("not connected"));
+  }
+}
+
+void loop() {
+  radar.read();
+  if (radar.isConnected() && millis() - lastReading > 1000) {
+    lastReading = millis();
+    if (radar.presenceDetected()) {
+      if (radar.stationaryTargetDetected()) {
+        Serial.print(F("Stationary target: "));
+        Serial.print(radar.stationaryTargetDistance());
+        Serial.print(F("cm energy:"));
+        Serial.print(radar.stationaryTargetEnergy());
+        Serial.print(' ');
+      }
+      if (radar.movingTargetDetected()) {
+        Serial.print(F("Moving target: "));
+        Serial.print(radar.movingTargetDistance());
+        Serial.print(F("cm energy:"));
+        Serial.print(radar.movingTargetEnergy());
+      }
+      Serial.println();
+    } else {
+      Serial.println(F("No target"));
+    }
+  }
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -26,6 +26,7 @@ stationaryEnergyAtGate	KEYWORD2
 engineeringRetrieved	KEYWORD2
 autoReadTask	KEYWORD2
 stopAutoReadTask	KEYWORD2
+isAutoReadTaskRunning	KEYWORD2
 
 firmware_major_version	LITERAL1
 firmware_minor_version	LITERAL1

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,14 +11,21 @@ stationaryTargetEnergy	KEYWORD2
 movingTargetDetected	KEYWORD2
 movingTargetDistance	KEYWORD2
 movingTargetEnergy	KEYWORD2
-requestFirmwareVersion
-requestCurrentConfiguration
+requestFirmwareVersion	KEYWORD2
+requestCurrentConfiguration	KEYWORD2
 requestRestart	KEYWORD2
 requestFactoryReset	KEYWORD2
 requestStartEngineeringMode	KEYWORD2
 requestEndEngineeringMode	KEYWORD2
 setMaxValues	KEYWORD2
 setGateSensitivityThreshold	KEYWORD2
+getFrameData	KEYWORD2
+detectionDistance	KEYWORD2
+movingEnergyAtGate	KEYWORD2
+stationaryEnergyAtGate	KEYWORD2
+engineeringRetrieved	KEYWORD2
+autoReadTask	KEYWORD2
+stopAutoReadTask	KEYWORD2
 
 firmware_major_version	LITERAL1
 firmware_minor_version	LITERAL1

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -14,21 +14,11 @@
 #define ld2410_cpp
 #include "ld2410.h"
 
-
-uint8_t circular_buffer[LD2410_BUFFER_SIZE];
-uint16_t buffer_head = 0;
-uint16_t buffer_tail = 0;
-
-// Enumerazione per lo stato del parsing
-enum ParseState { WAITING_START, READING_LENGTH, READING_DATA, CHECKING_END };
-ParseState current_state = WAITING_START;
-
-// Buffer pre-allocato per il frame
-#define MAX_FRAME_SIZE 1024
-uint8_t frame_buffer[MAX_FRAME_SIZE];
-uint16_t frame_position = 0;
-uint16_t frame_length = 0;
-
+// Magic header bytes for the two frame kinds. The protocol document
+// (HLK-LD2410C V1.00 §2.3) defines them as fixed 4-byte preambles; the
+// parser validates all four bytes before committing to a frame.
+static const uint8_t LD2410_DATA_HDR[4] = {0xF4, 0xF3, 0xF2, 0xF1};
+static const uint8_t LD2410_CMD_HDR[4]  = {0xFD, 0xFC, 0xFB, 0xFA};
 
 ld2410::ld2410()	//Constructor function
 {
@@ -58,25 +48,6 @@ bool ld2410::read_from_buffer(uint8_t &byte) {
         buffer_tail = (buffer_tail + 1) % LD2410_BUFFER_SIZE;
         return true;
     }
-}
-
-bool ld2410::find_frame_start() {
-    uint8_t byte;
-
-    // Continua a leggere dal buffer finché non trovi l'inizio del frame
-    while (read_from_buffer(byte)) {
-        // Controlla se il byte è l'inizio di un frame
-        if (byte == 0xF4 || byte == 0xFD) {
-            // Inizia un nuovo frame
-            radar_data_frame_[0] = byte;
-            radar_data_frame_position_ = 1;  // Reset della posizione del frame
-            frame_started_ = true;
-            ack_frame_ = (byte == 0xFD);  // Determina il tipo di frame (ack o data)
-            return true;
-        }
-    }
-
-    return false;  // Nessun frame trovato
 }
 
 bool ld2410::begin(Stream &radarStream, bool waitForRadar) {
@@ -355,47 +326,94 @@ void ld2410::print_frame_()
 	}
 }
 
+// Length-driven frame parser.
+//
+// Layout (HLK-LD2410C protocol V1.00 §2.3):
+//   [0..3]  4-byte magic header  (F4 F3 F2 F1 for data, FD FC FB FA for cmd)
+//   [4..5]  intra-frame data length, little-endian (uint16)
+//   [6..N]  intra-frame data, exactly `intra_len` bytes
+//   [N+1..N+4] 4-byte footer    (F8 F7 F6 F5 for data, 04 03 02 01 for cmd)
+// Total frame length = intra_len + 10.
+//
+// The previous parser (a) committed to a frame after a single 0xF4/0xFD byte
+// and (b) tested the footer pattern after every byte from position 8 onwards.
+// Both broke alignment under any kind of byte loss or when intra-frame data
+// happened to contain bytes resembling the footer (e.g. a stationary distance
+// of 244 cm has 0xF4 as its low byte). This version validates all four header
+// bytes before committing, captures the length once, accumulates exactly that
+// many bytes, then validates the footer and parses. On any mid-frame
+// inconsistency it resyncs, and if the offending byte is itself a candidate
+// header start it is reused as the new position 0 so we don't lose a header.
 bool ld2410::read_frame_() {
     uint8_t byte_read;
-    while (read_from_buffer(byte_read)) {  // Corrected to pass byte_read by reference
-        // If the frame has not started, check for the frame start
-        if (!frame_started_) {
-            if (byte_read == 0xF4 || byte_read == 0xFD) {
+    while (read_from_buffer(byte_read)) {
+        const uint8_t pos = radar_data_frame_position_;
+
+        // Stage A: locate the magic header (positions 0..3).
+        if (pos == 0) {
+            if (byte_read == 0xF4) {
                 radar_data_frame_[0] = byte_read;
                 radar_data_frame_position_ = 1;
-                frame_started_ = true;
-                ack_frame_ = (byte_read == 0xFD);  // Determine the type of frame
+                ack_frame_ = false;
+            } else if (byte_read == 0xFD) {
+                radar_data_frame_[0] = byte_read;
+                radar_data_frame_position_ = 1;
+                ack_frame_ = true;
             }
-        } else {
-            // Continue accumulating the frame bytes
-            radar_data_frame_[radar_data_frame_position_++] = byte_read;
-
-            // After reading at least 8 bytes, verify the frame length
-            if (radar_data_frame_position_ == 8) {
-                uint16_t intra_frame_data_length = radar_data_frame_[4] | (radar_data_frame_[5] << 8);
-
-                // Check if the frame length exceeds the maximum allowed
-                if (intra_frame_data_length + 10 > LD2410_MAX_FRAME_LENGTH) {
-                    frame_started_ = false;
-                    radar_data_frame_position_ = 0;
-                    continue;  // Skip this frame
-                }
-            }
-
-            // Check if the frame is complete
-            if (radar_data_frame_position_ >= 8 && check_frame_end_()) {
-                frame_started_ = false;  // Reset state for the next frame
-
-                // Process the frame (command or data)
-                if (ack_frame_) {
-                    return parse_command_frame_();
-                } else {
-                    return parse_data_frame_();
-                }
-            }
+            // else: drop byte, keep scanning
+            continue;
         }
+
+        if (pos < 4) {
+            const uint8_t expected = (ack_frame_ ? LD2410_CMD_HDR : LD2410_DATA_HDR)[pos];
+            if (byte_read == expected) {
+                radar_data_frame_[pos] = byte_read;
+                radar_data_frame_position_ = pos + 1;
+            } else if (byte_read == 0xF4) {
+                radar_data_frame_[0] = byte_read;
+                radar_data_frame_position_ = 1;
+                ack_frame_ = false;
+            } else if (byte_read == 0xFD) {
+                radar_data_frame_[0] = byte_read;
+                radar_data_frame_position_ = 1;
+                ack_frame_ = true;
+            } else {
+                radar_data_frame_position_ = 0;
+            }
+            continue;
+        }
+
+        // Stage B: capture the length field, then the body.
+        radar_data_frame_[pos] = byte_read;
+        radar_data_frame_position_ = pos + 1;
+
+        if (pos == 5) {
+            const uint16_t intra = (uint16_t)radar_data_frame_[4]
+                                 | ((uint16_t)radar_data_frame_[5] << 8);
+            if (intra == 0 || intra + 10 > LD2410_MAX_FRAME_LENGTH) {
+                radar_data_frame_position_ = 0;
+            }
+            continue;
+        }
+
+        if (pos < 6) continue;
+
+        const uint16_t intra = (uint16_t)radar_data_frame_[4]
+                             | ((uint16_t)radar_data_frame_[5] << 8);
+        const uint16_t total = intra + 10;
+        if (radar_data_frame_position_ < total) continue;
+
+        // Frame fully received. Validate footer once at the known position.
+        const bool footer_ok = check_frame_end_();
+        const bool was_ack   = ack_frame_;
+        bool ok = false;
+        if (footer_ok) {
+            ok = was_ack ? parse_command_frame_() : parse_data_frame_();
+        }
+        radar_data_frame_position_ = 0;
+        if (ok) return true;
     }
-    return false;  // No complete frame was found
+    return false;
 }
 
 bool ld2410::parse_data_frame_() {
@@ -497,7 +515,6 @@ void ld2410::begin_command_(uint8_t expected_op)
 		// so a stale ACK left over from a previous timeout cannot be matched
 		// by the new command.
 		buffer_tail = buffer_head;
-		frame_started_ = false;
 		radar_data_frame_position_ = 0;
 	}
 #if defined(ESP32)
@@ -1036,7 +1053,6 @@ bool ld2410::requestRestart()
 #if defined(ESP32)
 			portENTER_CRITICAL(&data_mux_);
 			buffer_tail = buffer_head;
-			frame_started_ = false;
 			radar_data_frame_position_ = 0;
 			portEXIT_CRITICAL(&data_mux_);
 			if (suspended != nullptr) {
@@ -1044,7 +1060,6 @@ bool ld2410::requestRestart()
 			}
 #else
 			buffer_tail = buffer_head;
-			frame_started_ = false;
 			radar_data_frame_position_ = 0;
 #endif
 		}

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -947,26 +947,51 @@ bool ld2410::leave_configuration_mode_()
 
 bool ld2410::requestStartEngineeringMode()
 {
-	begin_command_(0x62);
-	send_command_preamble_();
-	radar_uart_->write((byte) 0x02);	//Command is two bytes long
-	radar_uart_->write((byte) 0x00);
-	radar_uart_->write((byte) 0x62);	//Request enter engineering mode
-	radar_uart_->write((byte) 0x00);
-	send_command_postamble_();
-	return wait_for_ack_(0x62, radar_uart_command_timeout_);
+	// Per protocol §2.4.1, every config command must be issued inside an
+	// enter/leave configuration window — otherwise the radar silently
+	// rejects it. The other request*/set* helpers all wrap; these two
+	// engineering-mode helpers were originally missing the wrap, which
+	// caused the command to time out without an ACK.
+	if(enter_configuration_mode_())
+	{
+		delay(50);
+		begin_command_(0x62);
+		send_command_preamble_();
+		radar_uart_->write((byte) 0x02);	//Command is two bytes long
+		radar_uart_->write((byte) 0x00);
+		radar_uart_->write((byte) 0x62);	//Request enter engineering mode
+		radar_uart_->write((byte) 0x00);
+		send_command_postamble_();
+		bool ok = wait_for_ack_(0x62, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
+	}
+	delay(50);
+	leave_configuration_mode_();
+	return false;
 }
 
 bool ld2410::requestEndEngineeringMode()
 {
-	begin_command_(0x63);
-	send_command_preamble_();
-	radar_uart_->write((byte) 0x02);	//Command is two bytes long
-	radar_uart_->write((byte) 0x00);
-	radar_uart_->write((byte) 0x63);	//Request leave engineering mode
-	radar_uart_->write((byte) 0x00);
-	send_command_postamble_();
-	return wait_for_ack_(0x63, radar_uart_command_timeout_);
+	if(enter_configuration_mode_())
+	{
+		delay(50);
+		begin_command_(0x63);
+		send_command_preamble_();
+		radar_uart_->write((byte) 0x02);	//Command is two bytes long
+		radar_uart_->write((byte) 0x00);
+		radar_uart_->write((byte) 0x63);	//Request leave engineering mode
+		radar_uart_->write((byte) 0x00);
+		send_command_postamble_();
+		bool ok = wait_for_ack_(0x63, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
+	}
+	delay(50);
+	leave_configuration_mode_();
+	return false;
 }
 
 bool ld2410::requestCurrentConfiguration()

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -275,6 +275,27 @@ uint8_t ld2410::movingTargetEnergy() {
     return moving_target_energy_;  // Restituisci il valore se è già compreso tra 0 e 100
 }
 
+uint16_t ld2410::detectionDistance() {
+    return detection_distance_;
+}
+
+uint8_t ld2410::movingEnergyAtGate(uint8_t gate) {
+    if (gate >= 9) {
+        return 0;
+    }
+    return engineering_motion_energy_[gate];
+}
+
+uint8_t ld2410::stationaryEnergyAtGate(uint8_t gate) {
+    if (gate >= 9) {
+        return 0;
+    }
+    return engineering_stationary_energy_[gate];
+}
+
+bool ld2410::engineeringRetrieved() {
+    return engineering_data_received_;
+}
 
 
 bool ld2410::check_frame_end_() {
@@ -369,29 +390,53 @@ bool ld2410::read_frame_() {
 bool ld2410::parse_data_frame_() {
     uint16_t intra_frame_data_length = radar_data_frame_[4] | (radar_data_frame_[5] << 8);
 
-    // Verifica se la lunghezza del frame è corretta
+    // Frame totale = header(4) + length(2) + intra-frame + footer(4) = intra+10
     if (radar_data_frame_position_ != intra_frame_data_length + 10) {
         return false;
     }
 
-    // Controllo dei byte specifici per validare il frame
-    if (radar_data_frame_[6] == 0x02 && radar_data_frame_[7] == 0xAA &&
-        radar_data_frame_[17] == 0x55 && radar_data_frame_[18] == 0x00) {
-
-        target_type_ = radar_data_frame_[8];
-
-        // Estrai distanze e energie dei bersagli
-        stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[12]);
-        moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
-        stationary_target_energy_ = radar_data_frame_[14];
-        moving_target_energy_ = radar_data_frame_[11];
-
-        last_valid_frame_length = radar_data_frame_position_;  // Aggiunto per tracciare la lunghezza del frame
-        radar_uart_last_packet_ = millis();  // Aggiorna il timestamp dell'ultimo pacchetto
-        return true;
+    // Per Tabella 11, il primo byte intra-frame indica il tipo: 0x02 basic, 0x01 engineering.
+    uint8_t data_type = radar_data_frame_[6];
+    if (data_type != 0x01 && data_type != 0x02) {
+        return false;
     }
 
-    return false;  // Frame non valido
+    // Per Tabella 10, i marker di coda 0x55 0x00 sono SEMPRE gli ultimi 2 byte
+    // dell'intra-frame data: per il basic frame (intra=13) coincidono con [17][18]
+    // ma in engineering la posizione varia. Calcoliamo gli offset dinamicamente.
+    uint16_t tail_index = intra_frame_data_length + 4;        // 0x55
+    uint16_t cal_index = intra_frame_data_length + 5;         // 0x00
+    if (radar_data_frame_[7] != 0xAA ||
+        radar_data_frame_[tail_index] != 0x55 ||
+        radar_data_frame_[cal_index] != 0x00) {
+        return false;
+    }
+
+    // Tabella 12: dati basic (presenti sia in 0x01 che in 0x02)
+    target_type_ = radar_data_frame_[8];
+    moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
+    moving_target_energy_ = radar_data_frame_[11];
+    stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[12]);
+    stationary_target_energy_ = radar_data_frame_[14];
+    detection_distance_ = *(uint16_t*)(&radar_data_frame_[15]);
+
+    // Tabella 14: extra engineering. Layout (full-frame index, 0-based):
+    //   17 = max moving gate N (ridondante con max_moving_gate da requestCurrentConfiguration)
+    //   18 = max stationary gate N
+    //   19..27 = energie motion gate 0..8
+    //   28..36 = energie stationary gate 0..8
+    //   poi M byte di retain + tail/cal (gestiti sopra)
+    if (data_type == 0x01 && intra_frame_data_length >= 33) {
+        for (uint8_t gate = 0; gate < 9; gate++) {
+            engineering_motion_energy_[gate] = radar_data_frame_[19 + gate];
+            engineering_stationary_energy_[gate] = radar_data_frame_[28 + gate];
+        }
+        engineering_data_received_ = true;
+    }
+
+    last_valid_frame_length = radar_data_frame_position_;
+    radar_uart_last_packet_ = millis();
+    return true;
 }
 
 

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -450,6 +450,98 @@ bool ld2410::parse_data_frame_() {
 }
 
 
+// ---------------------------------------------------------------------------
+// Command synchronization helpers.
+//
+// begin_command_() is called by every request*/set* function right before
+// writing the command bytes to the UART. It bumps cmd_seq_ and resets the
+// expected-ACK opcode under data_mux_, and -- when no autoReadTask is
+// running -- discards any stale frame state (circular buffer, in-progress
+// parser state, UART RX FIFO bytes) from a previous command that may have
+// timed out. When the task is running it must NOT touch UART or buffer
+// state because the task owns them; the seq bump alone is enough to
+// invalidate stale ACKs.
+//
+// wait_for_ack_() drives the wait loop. Two modes:
+//   - no task running: drains UART hardware into the circular buffer and
+//     calls read_frame_() ourselves until either a matching ACK is parsed
+//     or the timeout expires.
+//   - task running:    leaves UART alone; polls cmd_ack_seq_ while letting
+//     the task fill the buffer and parse frames in its own context.
+// In both modes the matching condition is identical:
+//   cmd_ack_seq_ == cmd_seq_ AND latest_ack_ == expected_op
+// returning latest_command_success_ on match, false on timeout.
+// ---------------------------------------------------------------------------
+void ld2410::begin_command_(uint8_t expected_op)
+{
+	bool task_running = false;
+#if defined(ESP32)
+	task_running = (taskHandle_ != nullptr);
+	portENTER_CRITICAL(&data_mux_);
+#endif
+	expected_ack_opcode_ = expected_op;
+	cmd_seq_++;
+	if (!task_running) {
+		// Discard any half-parsed frame and drop the circular buffer contents
+		// so a stale ACK left over from a previous timeout cannot be matched
+		// by the new command.
+		buffer_tail = buffer_head;
+		frame_started_ = false;
+		radar_data_frame_position_ = 0;
+	}
+#if defined(ESP32)
+	portEXIT_CRITICAL(&data_mux_);
+#endif
+	if (!task_running) {
+		// Drain in-flight UART bytes from the previous command's timeout.
+		while (radar_uart_->available()) {
+			radar_uart_->read();
+		}
+	}
+}
+
+bool ld2410::wait_for_ack_(uint8_t expected_op, uint32_t timeout_ms)
+{
+	uint32_t start = millis();
+	bool task_running = false;
+#if defined(ESP32)
+	task_running = (taskHandle_ != nullptr);
+#endif
+	while (millis() - start < timeout_ms) {
+		if (!task_running) {
+			// Drive UART -> circular buffer -> parser ourselves
+			while (radar_uart_->available()) {
+				add_to_buffer(radar_uart_->read());
+			}
+			read_frame_();
+		}
+
+		bool got_ack = false;
+		bool ok = false;
+#if defined(ESP32)
+		portENTER_CRITICAL(&data_mux_);
+#endif
+		if (cmd_ack_seq_ == cmd_seq_ && latest_ack_ == expected_op) {
+			got_ack = true;
+			ok = latest_command_success_;
+		}
+#if defined(ESP32)
+		portEXIT_CRITICAL(&data_mux_);
+#endif
+		if (got_ack) {
+			return ok;
+		}
+
+#if defined(ESP32)
+		if (task_running) {
+			vTaskDelay(pdMS_TO_TICKS(1));
+		}
+#endif
+		yield();
+	}
+	return false;
+}
+
 bool ld2410::parse_command_frame_()
 {
 	uint16_t intra_frame_data_length_ = radar_data_frame_[4] + (radar_data_frame_[5] << 8);
@@ -462,8 +554,23 @@ bool ld2410::parse_command_frame_()
 		debug_uart_->print(F(" bytes"));
 	}
 	#endif
-	latest_ack_ = radar_data_frame_[6];
-	latest_command_success_ = (radar_data_frame_[8] == 0x00 && radar_data_frame_[9] == 0x00);
+	// Atomic update of (latest_ack_, latest_command_success_, cmd_ack_seq_).
+	// wait_for_ack_() reads this triplet to decide if the current command's
+	// ACK has landed. cmd_ack_seq_ mirrors cmd_seq_ only on opcode match,
+	// preventing false positives from stale ACKs of previously-timed-out commands.
+	uint8_t this_ack = radar_data_frame_[6];
+	bool this_success = (radar_data_frame_[8] == 0x00 && radar_data_frame_[9] == 0x00);
+#if defined(ESP32)
+	portENTER_CRITICAL(&data_mux_);
+#endif
+	latest_ack_ = this_ack;
+	latest_command_success_ = this_success;
+	if (this_ack == expected_ack_opcode_) {
+		cmd_ack_seq_ = cmd_seq_;
+	}
+#if defined(ESP32)
+	portEXIT_CRITICAL(&data_mux_);
+#endif
 	if(intra_frame_data_length_ == 8 && latest_ack_ == 0xFF)
 	{
 		#ifdef LD2410_DEBUG_COMMANDS

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -217,6 +217,17 @@ void ld2410::stopAutoReadTask() {
 }
 #endif
 
+// Reports whether autoReadTask() is currently running. Always false on
+// platforms without the FreeRTOS task path, so consumer code can branch on
+// runtime mode without compile-time #ifs.
+bool ld2410::isAutoReadTaskRunning() {
+#if defined(ESP32)
+    return taskHandle_ != nullptr;
+#else
+    return false;
+#endif
+}
+
 
 bool ld2410::presenceDetected()
 {

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -1002,6 +1002,41 @@ bool ld2410::requestRestart()
 		bool ok = wait_for_ack_(0xA3, radar_uart_command_timeout_);
 		delay(50);
 		leave_configuration_mode_();
+		if (ok) {
+			// After ACK 0xA3 the radar reboots and emits ~500-800ms of garbage
+			// or silence on its UART. If autoReadTask is running it would
+			// happily feed those bytes to parse_data_frame_, occasionally
+			// matching a 0xF4/0xFD frame start and clobbering the field cache
+			// with synthetic data. Suspend the task across the reboot window,
+			// drain the UART RX FIFO and the circular buffer twice, then
+			// resume.
+#if defined(ESP32)
+			TaskHandle_t suspended = nullptr;
+			portENTER_CRITICAL(&data_mux_);
+			suspended = taskHandle_;
+			portEXIT_CRITICAL(&data_mux_);
+			if (suspended != nullptr) {
+				vTaskSuspend(suspended);
+			}
+#endif
+			while (radar_uart_->available()) radar_uart_->read();
+			delay(800);
+			while (radar_uart_->available()) radar_uart_->read();
+#if defined(ESP32)
+			portENTER_CRITICAL(&data_mux_);
+			buffer_tail = buffer_head;
+			frame_started_ = false;
+			radar_data_frame_position_ = 0;
+			portEXIT_CRITICAL(&data_mux_);
+			if (suspended != nullptr) {
+				vTaskResume(suspended);
+			}
+#else
+			buffer_tail = buffer_head;
+			frame_started_ = false;
+			radar_data_frame_position_ = 0;
+#endif
+		}
 		return ok;
 	}
 	delay(50);

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -413,6 +413,13 @@ bool ld2410::parse_data_frame_() {
     }
 
     // Tabella 12: dati basic (presenti sia in 0x01 che in 0x02)
+    // Sezione critica: su ESP32 dual-core il task pinnato a core 0 può aggiornare
+    // i campi mentre il loop utente li legge da core 1. Il critical section
+    // evita stati inconsistenti tra campi di uno stesso frame e funge da
+    // memory barrier per i lettori dei singoli getter.
+#if defined(ESP32)
+    portENTER_CRITICAL(&data_mux_);
+#endif
     target_type_ = radar_data_frame_[8];
     moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
     moving_target_energy_ = radar_data_frame_[11];
@@ -436,6 +443,9 @@ bool ld2410::parse_data_frame_() {
 
     last_valid_frame_length = radar_data_frame_position_;
     radar_uart_last_packet_ = millis();
+#if defined(ESP32)
+    portEXIT_CRITICAL(&data_mux_);
+#endif
     return true;
 }
 

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -185,17 +185,35 @@ void ld2410::taskFunction(void* param) {
     }
 }
 
-// Funzione per avviare il task
-void ld2410::autoReadTask(uint32_t stack, uint32_t priority, uint32_t core) {
-    xTaskCreatePinnedToCore(
+// Avvia il task FreeRTOS che legge in continuo dalla UART del radar.
+// Ritorna true se il task è stato creato con successo. Se un task era già
+// attivo viene ignorata la nuova richiesta e si ritorna true.
+bool ld2410::autoReadTask(uint32_t stack, UBaseType_t priority, BaseType_t core) {
+    if (taskHandle_ != nullptr) {
+        return true;
+    }
+    BaseType_t result = xTaskCreatePinnedToCore(
         taskFunction,
         "LD2410Task",
         stack,
         this,
         priority,
-        nullptr,
+        &taskHandle_,
         core
     );
+    if (result != pdPASS) {
+        taskHandle_ = nullptr;
+        return false;
+    }
+    return true;
+}
+
+// Ferma il task se in esecuzione.
+void ld2410::stopAutoReadTask() {
+    if (taskHandle_ != nullptr) {
+        vTaskDelete(taskHandle_);
+        taskHandle_ = nullptr;
+    }
 }
 #endif
 

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -164,6 +164,7 @@ bool ld2410::read() {
 }
 
 
+#if defined(ESP32)
 void ld2410::taskFunction(void* param) {
     ld2410* sensor = static_cast<ld2410*>(param);
     for (;;) {
@@ -196,6 +197,7 @@ void ld2410::autoReadTask(uint32_t stack, uint32_t priority, uint32_t core) {
         core
     );
 }
+#endif
 
 
 bool ld2410::presenceDetected()

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -893,8 +893,8 @@ void ld2410::send_command_postamble_()
 
 bool ld2410::enter_configuration_mode_()
 {
+	begin_command_(0xFF);
 	send_command_preamble_();
-	//Request firmware
 	radar_uart_->write((byte) 0x04);	//Command is four bytes long
 	radar_uart_->write((byte) 0x00);
 	radar_uart_->write((byte) 0xFF);	//Request enter command mode
@@ -902,87 +902,43 @@ bool ld2410::enter_configuration_mode_()
 	radar_uart_->write((byte) 0x01);
 	radar_uart_->write((byte) 0x00);
 	send_command_postamble_();
-	radar_uart_last_command_ = millis();
-	while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-	{
-		if(read_frame_no_buffer_())
-		{
-			if(latest_ack_ == 0xFF && latest_command_success_)
-			{
-				return true;
-			}
-		}
-	}
-	return false;
+	return wait_for_ack_(0xFF, radar_uart_command_timeout_);
 }
 
 bool ld2410::leave_configuration_mode_()
 {
+	begin_command_(0xFE);
 	send_command_preamble_();
-	//Request firmware
 	radar_uart_->write((byte) 0x02);	//Command is two bytes long
 	radar_uart_->write((byte) 0x00);
 	radar_uart_->write((byte) 0xFE);	//Request leave command mode
 	radar_uart_->write((byte) 0x00);
 	send_command_postamble_();
-	radar_uart_last_command_ = millis();
-	while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-	{
-		if(read_frame_no_buffer_())
-		{
-			if(latest_ack_ == 0xFE && latest_command_success_)
-			{
-				return true;
-			}
-		}
-	}
-	return false;
+	return wait_for_ack_(0xFE, radar_uart_command_timeout_);
 }
 
 bool ld2410::requestStartEngineeringMode()
 {
+	begin_command_(0x62);
 	send_command_preamble_();
-	//Request firmware
 	radar_uart_->write((byte) 0x02);	//Command is two bytes long
 	radar_uart_->write((byte) 0x00);
-	radar_uart_->write((byte) 0x62);	//Request enter command mode
+	radar_uart_->write((byte) 0x62);	//Request enter engineering mode
 	radar_uart_->write((byte) 0x00);
 	send_command_postamble_();
-	radar_uart_last_command_ = millis();
-	while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-	{
-		if(read_frame_no_buffer_())
-		{
-			if(latest_ack_ == 0x62 && latest_command_success_)
-			{
-				return true;
-			}
-		}
-	}
-	return false;
+	return wait_for_ack_(0x62, radar_uart_command_timeout_);
 }
 
 bool ld2410::requestEndEngineeringMode()
 {
+	begin_command_(0x63);
 	send_command_preamble_();
-	//Request firmware
 	radar_uart_->write((byte) 0x02);	//Command is two bytes long
 	radar_uart_->write((byte) 0x00);
-	radar_uart_->write((byte) 0x63);	//Request leave command mode
+	radar_uart_->write((byte) 0x63);	//Request leave engineering mode
 	radar_uart_->write((byte) 0x00);
 	send_command_postamble_();
-	radar_uart_last_command_ = millis();
-	while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-	{
-		if(read_frame_no_buffer_())
-		{
-			if(latest_ack_ == 0x63 && latest_command_success_)
-			{
-				return true;
-			}
-		}
-	}
-	return false;
+	return wait_for_ack_(0x63, radar_uart_command_timeout_);
 }
 
 bool ld2410::requestCurrentConfiguration()
@@ -990,26 +946,17 @@ bool ld2410::requestCurrentConfiguration()
 	if(enter_configuration_mode_())
 	{
 		delay(50);
+		begin_command_(0x61);
 		send_command_preamble_();
-		//Request firmware
 		radar_uart_->write((byte) 0x02);	//Command is two bytes long
 		radar_uart_->write((byte) 0x00);
 		radar_uart_->write((byte) 0x61);	//Request current configuration
 		radar_uart_->write((byte) 0x00);
 		send_command_postamble_();
-		radar_uart_last_command_ = millis();
-		while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-		{
-			if(read_frame_no_buffer_())
-			{
-				if(latest_ack_ == 0x61 && latest_command_success_)
-				{
-					delay(50);
-					leave_configuration_mode_();
-					return true;
-				}
-			}
-		}
+		bool ok = wait_for_ack_(0x61, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
 	}
 	delay(50);
 	leave_configuration_mode_();
@@ -1021,100 +968,21 @@ bool ld2410::requestFirmwareVersion()
 	if(enter_configuration_mode_())
 	{
 		delay(50);
+		begin_command_(0xA0);
 		send_command_preamble_();
-		//Request firmware
 		radar_uart_->write((byte) 0x02);	//Command is two bytes long
 		radar_uart_->write((byte) 0x00);
 		radar_uart_->write((byte) 0xA0);	//Request firmware version
 		radar_uart_->write((byte) 0x00);
 		send_command_postamble_();
-		radar_uart_last_command_ = millis();
-		while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-		{
-			read_frame_no_buffer_();
-			if(latest_ack_ == 0xA0 && latest_command_success_)
-			{
-				delay(50);
-				leave_configuration_mode_();
-				return true;
-			}
-		}
+		bool ok = wait_for_ack_(0xA0, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
 	}
 	delay(50);
 	leave_configuration_mode_();
 	return false;
-}
-
-
-bool ld2410::read_frame_no_buffer_() {
-    if(radar_uart_->available()) {
-        if(frame_started_ == false) {
-            uint8_t byte_read_ = radar_uart_->read();
-            if(byte_read_ == 0xF4) {
-                radar_data_frame_[radar_data_frame_position_++] = byte_read_;
-                frame_started_ = true;
-                ack_frame_ = false;
-            }
-            else if(byte_read_ == 0xFD) {
-                radar_data_frame_[radar_data_frame_position_++] = byte_read_;
-                frame_started_ = true;
-                ack_frame_ = true;
-            }
-        }
-        else {
-            if(radar_data_frame_position_ < LD2410_MAX_FRAME_LENGTH) {
-                radar_data_frame_[radar_data_frame_position_++] = radar_uart_->read();
-                
-                if(radar_data_frame_position_ > 7) {
-                    // Check data frame end
-                    if( radar_data_frame_[0] == 0xF4 &&
-                        radar_data_frame_[1] == 0xF3 &&
-                        radar_data_frame_[2] == 0xF2 &&
-                        radar_data_frame_[3] == 0xF1 &&
-                        radar_data_frame_[radar_data_frame_position_ - 4] == 0xF8 &&
-                        radar_data_frame_[radar_data_frame_position_ - 3] == 0xF7 &&
-                        radar_data_frame_[radar_data_frame_position_ - 2] == 0xF6 &&
-                        radar_data_frame_[radar_data_frame_position_ - 1] == 0xF5)
-                    {
-                        if(parse_data_frame_()) {
-                            frame_started_ = false;
-                            radar_data_frame_position_ = 0;
-                            return true;
-                        }
-                        else {
-                            frame_started_ = false;
-                            radar_data_frame_position_ = 0;
-                        }
-                    }
-                    // Check command frame end
-                    else if(radar_data_frame_[0] == 0xFD &&
-                            radar_data_frame_[1] == 0xFC &&
-                            radar_data_frame_[2] == 0xFB &&
-                            radar_data_frame_[3] == 0xFA &&
-                            radar_data_frame_[radar_data_frame_position_ - 4] == 0x04 &&
-                            radar_data_frame_[radar_data_frame_position_ - 3] == 0x03 &&
-                            radar_data_frame_[radar_data_frame_position_ - 2] == 0x02 &&
-                            radar_data_frame_[radar_data_frame_position_ - 1] == 0x01)
-                    {
-                        if(parse_command_frame_()) {
-                            frame_started_ = false;
-                            radar_data_frame_position_ = 0;
-                            return true;
-                        }
-                        else {
-                            frame_started_ = false;
-                            radar_data_frame_position_ = 0;
-                        }
-                    }
-                }
-            }
-            else {
-                frame_started_ = false;
-                radar_data_frame_position_ = 0;
-            }
-        }
-    }
-    return false;
 }
 
 
@@ -1124,26 +992,17 @@ bool ld2410::requestRestart()
 	if(enter_configuration_mode_())
 	{
 		delay(50);
+		begin_command_(0xA3);
 		send_command_preamble_();
-		//Request firmware
 		radar_uart_->write((byte) 0x02);	//Command is two bytes long
 		radar_uart_->write((byte) 0x00);
 		radar_uart_->write((byte) 0xA3);	//Request restart
 		radar_uart_->write((byte) 0x00);
 		send_command_postamble_();
-		radar_uart_last_command_ = millis();
-		while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-		{
-			if(read_frame_())
-			{
-				if(latest_ack_ == 0xA3 && latest_command_success_)
-				{
-					delay(50);
-					leave_configuration_mode_();
-					return true;
-				}
-			}
-		}
+		bool ok = wait_for_ack_(0xA3, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
 	}
 	delay(50);
 	leave_configuration_mode_();
@@ -1155,26 +1014,17 @@ bool ld2410::requestFactoryReset()
 	if(enter_configuration_mode_())
 	{
 		delay(50);
+		begin_command_(0xA2);
 		send_command_preamble_();
-		//Request firmware
 		radar_uart_->write((byte) 0x02);	//Command is two bytes long
 		radar_uart_->write((byte) 0x00);
 		radar_uart_->write((byte) 0xA2);	//Request factory reset
 		radar_uart_->write((byte) 0x00);
 		send_command_postamble_();
-		radar_uart_last_command_ = millis();
-		while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-		{
-			if(read_frame_())
-			{
-				if(latest_ack_ == 0xA2 && latest_command_success_)
-				{
-					delay(50);
-					leave_configuration_mode_();
-					return true;
-				}
-			}
-		}
+		bool ok = wait_for_ack_(0xA2, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
 	}
 	delay(50);
 	leave_configuration_mode_();
@@ -1186,6 +1036,7 @@ bool ld2410::setMaxValues(uint16_t moving, uint16_t stationary, uint16_t inactiv
 	if(enter_configuration_mode_())
 	{
 		delay(50);
+		begin_command_(0x60);
 		send_command_preamble_();
 		radar_uart_->write((byte) 0x14);	//Command is 20 bytes long
 		radar_uart_->write((byte) 0x00);
@@ -1210,19 +1061,10 @@ bool ld2410::setMaxValues(uint16_t moving, uint16_t stationary, uint16_t inactiv
 		radar_uart_->write((byte) 0x00);	//Spacer
 		radar_uart_->write((byte) 0x00);
 		send_command_postamble_();
-		radar_uart_last_command_ = millis();
-		while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-		{
-			if(read_frame_())
-			{
-				if(latest_ack_ == 0x60 && latest_command_success_)
-				{
-					delay(50);
-					leave_configuration_mode_();
-					return true;
-				}
-			}
-		}
+		bool ok = wait_for_ack_(0x60, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
 	}
 	delay(50);
 	leave_configuration_mode_();
@@ -1234,6 +1076,7 @@ bool ld2410::setGateSensitivityThreshold(uint8_t gate, uint8_t moving, uint8_t s
 	if(enter_configuration_mode_())
 	{
 		delay(50);
+		begin_command_(0x64);
 		send_command_preamble_();
 		radar_uart_->write((byte) 0x14);	//Command is 20 bytes long
 		radar_uart_->write((byte) 0x00);
@@ -1258,19 +1101,10 @@ bool ld2410::setGateSensitivityThreshold(uint8_t gate, uint8_t moving, uint8_t s
 		radar_uart_->write((byte) 0x00);	//Spacer
 		radar_uart_->write((byte) 0x00);
 		send_command_postamble_();
-		radar_uart_last_command_ = millis();
-		while(millis() - radar_uart_last_command_ < radar_uart_command_timeout_)
-		{
-			if(read_frame_())
-			{
-				if(latest_ack_ == 0x64 && latest_command_success_)
-				{
-					delay(50);
-					leave_configuration_mode_();
-					return true;
-				}
-			}
-		}
+		bool ok = wait_for_ack_(0x64, radar_uart_command_timeout_);
+		delay(50);
+		leave_configuration_mode_();
+		return ok;
 	}
 	delay(50);
 	leave_configuration_mode_();

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -61,7 +61,9 @@ class ld2410	{
 		bool setMaxValues(uint16_t moving, uint16_t stationary, uint16_t inactivityTimer);	//Realistically gate values are 0-8 but sent as uint16_t
 		bool setGateSensitivityThreshold(uint8_t gate, uint8_t moving, uint8_t stationary);
     	FrameData getFrameData() const;
+#if defined(ESP32)
 		void autoReadTask(uint32_t stack, uint32_t priority, uint32_t core);
+#endif
 
 	protected:
 	private:
@@ -104,6 +106,8 @@ class ld2410	{
 		void send_command_postamble_();									//Commands have the same postamble
 		bool enter_configuration_mode_();								//Necessary before sending any command
 		bool leave_configuration_mode_();								//Will not read values without leaving command mode
+#if defined(ESP32)
 		static void taskFunction(void* param);
+#endif
 };
 #endif

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -101,6 +101,7 @@ class ld2410	{
 		bool engineering_data_received_ = false;
 #if defined(ESP32)
 		TaskHandle_t taskHandle_ = nullptr;
+		portMUX_TYPE data_mux_ = portMUX_INITIALIZER_UNLOCKED;
 #endif
 
 		uint8_t circular_buffer[LD2410_BUFFER_SIZE];

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -80,7 +80,6 @@ class ld2410	{
 		Stream *debug_uart_ = nullptr;									//The stream used for the debugging
 		uint32_t radar_uart_timeout = 100;								//How long to give up on receiving some useful data from the LD2410
 		uint32_t radar_uart_last_packet_ = 0;							//Time of the last packet from the radar
-		uint32_t radar_uart_last_command_ = 0;							//Time of the last command sent to the radar
 		uint32_t radar_uart_command_timeout_ = 100;						//Timeout for sending commands
 		uint8_t latest_ack_ = 0;
 		bool latest_command_success_ = false;
@@ -118,7 +117,6 @@ class ld2410	{
         bool check_frame_end_();
 		
 		bool read_frame_();		
-		bool read_frame_no_buffer_();										//Try to read a frame from the UART
 		bool parse_data_frame_();										//Is the current data frame valid?
 		bool parse_command_frame_();									//Is the current command frame valid?
 		void begin_command_(uint8_t expected_op);						//Bump cmd_seq_, reset stale state, set expected ACK opcode

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -13,6 +13,10 @@
 #ifndef ld2410_h
 #define ld2410_h
 #include <Arduino.h>
+#if defined(ESP32)
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#endif
 
 #define LD2410_MAX_FRAME_LENGTH 40
 #ifndef LD2410_BUFFER_SIZE
@@ -62,7 +66,8 @@ class ld2410	{
 		bool setGateSensitivityThreshold(uint8_t gate, uint8_t moving, uint8_t stationary);
     	FrameData getFrameData() const;
 #if defined(ESP32)
-		void autoReadTask(uint32_t stack, uint32_t priority, uint32_t core);
+		bool autoReadTask(uint32_t stack = 4096, UBaseType_t priority = 1, BaseType_t core = tskNO_AFFINITY);
+		void stopAutoReadTask();
 #endif
 
 	protected:
@@ -86,6 +91,9 @@ class ld2410	{
 		uint16_t stationary_target_distance_ = 0;
 		uint8_t stationary_target_energy_ = 0;
     	uint16_t last_valid_frame_length = 0;
+#if defined(ESP32)
+		TaskHandle_t taskHandle_ = nullptr;
+#endif
 
 		uint8_t circular_buffer[LD2410_BUFFER_SIZE];
         uint16_t buffer_head = 0;

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -85,8 +85,7 @@ class ld2410	{
 		uint8_t latest_ack_ = 0;
 		bool latest_command_success_ = false;
 		uint8_t radar_data_frame_[LD2410_MAX_FRAME_LENGTH];				//Store the incoming data from the radar, to check it's in a valid format
-		uint8_t radar_data_frame_position_ = 0;							//Where in the frame we are currently writing
-		bool frame_started_ = false;									//Whether a frame is currently being read
+		uint8_t radar_data_frame_position_ = 0;							//Where in the frame we are currently writing; 0 means no frame in progress
 		bool ack_frame_ = false;										//Whether the incoming frame is LIKELY an ACK frame
 		bool waiting_for_ack_ = false;									//Whether a command has just been sent
 		uint8_t target_type_ = 0;
@@ -111,11 +110,9 @@ class ld2410	{
         uint16_t buffer_head = 0;
         uint16_t buffer_tail = 0;
 
-        // Nuove funzioni private
 		void add_to_buffer(uint8_t byte);
 		bool read_from_buffer(uint8_t &byte);
-        bool find_frame_start();
-        bool check_frame_end_();
+		bool check_frame_end_();
 		
 		bool read_frame_();		
 		bool parse_data_frame_();										//Is the current data frame valid?

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -99,6 +99,9 @@ class ld2410	{
 		uint8_t engineering_motion_energy_[9] = {0,0,0,0,0,0,0,0,0};
 		uint8_t engineering_stationary_energy_[9] = {0,0,0,0,0,0,0,0,0};
 		bool engineering_data_received_ = false;
+		uint8_t cmd_seq_ = 0;											//Monotonic counter; bumped before each command issue
+		uint8_t cmd_ack_seq_ = 0;										//Mirrored by parser when an ACK matches expected_ack_opcode_
+		uint8_t expected_ack_opcode_ = 0;								//Set by command issuer; checked by parse_command_frame_
 #if defined(ESP32)
 		TaskHandle_t taskHandle_ = nullptr;
 		portMUX_TYPE data_mux_ = portMUX_INITIALIZER_UNLOCKED;
@@ -118,6 +121,8 @@ class ld2410	{
 		bool read_frame_no_buffer_();										//Try to read a frame from the UART
 		bool parse_data_frame_();										//Is the current data frame valid?
 		bool parse_command_frame_();									//Is the current command frame valid?
+		void begin_command_(uint8_t expected_op);						//Bump cmd_seq_, reset stale state, set expected ACK opcode
+		bool wait_for_ack_(uint8_t expected_op, uint32_t timeout_ms);	//Block until matching ACK arrives or timeout
 		void print_frame_();											//Print the frame for debugging
 		void send_command_preamble_();									//Commands have the same preamble
 		void send_command_postamble_();									//Commands have the same postamble

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -69,6 +69,7 @@ class ld2410	{
 		bool setMaxValues(uint16_t moving, uint16_t stationary, uint16_t inactivityTimer);	//Realistically gate values are 0-8 but sent as uint16_t
 		bool setGateSensitivityThreshold(uint8_t gate, uint8_t moving, uint8_t stationary);
     	FrameData getFrameData() const;
+		bool isAutoReadTaskRunning();									//True iff autoReadTask() succeeded and the task hasn't been stopped (always false on non-ESP32)
 #if defined(ESP32)
 		bool autoReadTask(uint32_t stack = 4096, UBaseType_t priority = 1, BaseType_t core = tskNO_AFFINITY);
 		void stopAutoReadTask();

--- a/src/ld2410.h
+++ b/src/ld2410.h
@@ -18,7 +18,7 @@
 #include <freertos/task.h>
 #endif
 
-#define LD2410_MAX_FRAME_LENGTH 40
+#define LD2410_MAX_FRAME_LENGTH 64
 #ifndef LD2410_BUFFER_SIZE
 #define LD2410_BUFFER_SIZE 256
 #endif
@@ -47,6 +47,10 @@ class ld2410	{
 		bool movingTargetDetected();
 		uint16_t movingTargetDistance();
 		uint8_t movingTargetEnergy();
+		uint16_t detectionDistance();									//Last reported detection distance in cm (Table 12, last field)
+		uint8_t movingEnergyAtGate(uint8_t gate);						//Per-gate motion energy from engineering frames (Table 14)
+		uint8_t stationaryEnergyAtGate(uint8_t gate);				//Per-gate stationary energy from engineering frames (Table 14)
+		bool engineeringRetrieved();								//True once at least one engineering-mode data frame has been parsed
 		bool requestFirmwareVersion();									//Request the firmware version
 		uint8_t firmware_major_version = 0;								//Reported major version
 		uint8_t firmware_minor_version = 0;								//Reported minor version
@@ -91,6 +95,10 @@ class ld2410	{
 		uint16_t stationary_target_distance_ = 0;
 		uint8_t stationary_target_energy_ = 0;
     	uint16_t last_valid_frame_length = 0;
+		uint16_t detection_distance_ = 0;
+		uint8_t engineering_motion_energy_[9] = {0,0,0,0,0,0,0,0,0};
+		uint8_t engineering_stationary_energy_[9] = {0,0,0,0,0,0,0,0,0};
+		bool engineering_data_received_ = false;
 #if defined(ESP32)
 		TaskHandle_t taskHandle_ = nullptr;
 #endif

--- a/tests/Arduino.h
+++ b/tests/Arduino.h
@@ -1,0 +1,49 @@
+// Minimal Arduino stub for host-side unit testing of ld2410.cpp.
+// Only exposes the surface that src/ld2410.cpp actually uses:
+//   Stream / Print interface, millis(), F() macro, yield(), HEX/DEC constants.
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HEX 16
+#define DEC 10
+#define F(s) (s)
+typedef const char* __FlashStringHelper;
+
+typedef uint8_t byte;
+
+inline unsigned long millis() {
+    static unsigned long t = 1;
+    return ++t;
+}
+
+inline void yield() {}
+inline void delay(unsigned long /*ms*/) {}
+
+class Print {
+public:
+    virtual size_t write(uint8_t) { return 1; }
+    virtual size_t write(const uint8_t* /*buf*/, size_t n) { return n; }
+    size_t print(const char*) { return 0; }
+    size_t print(char) { return 0; }
+    size_t print(int, int = DEC) { return 0; }
+    size_t print(unsigned int, int = DEC) { return 0; }
+    size_t print(long, int = DEC) { return 0; }
+    size_t print(unsigned long, int = DEC) { return 0; }
+    size_t print(double, int = 2) { return 0; }
+    size_t print(unsigned char, int = DEC) { return 0; }
+    size_t println() { return 0; }
+    size_t println(const char* s) { return print(s); }
+    template<typename T> size_t println(T x) { return print(x); }
+    template<typename T, typename U> size_t println(T x, U y) { return print(x, y); }
+};
+
+class Stream : public Print {
+public:
+    virtual int available() = 0;
+    virtual int read() = 0;
+    virtual int peek() { return -1; }
+    virtual ~Stream() {}
+};

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Build and run the host-side parser unit tests.
+# Usage: bash tests/run.sh   (from the repo root, or anywhere)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+BIN="$HERE/test_parser"
+
+g++ -std=c++17 -Wall -Wextra \
+    -I"$HERE" \
+    -I"$ROOT/src" \
+    "$HERE/test_parser.cpp" \
+    "$ROOT/src/ld2410.cpp" \
+    -o "$BIN"
+
+"$BIN"

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -430,6 +430,122 @@ static void test_command_no_ack() {
     std::printf("ok\n");
 }
 
+// ---------------------------------------------------------------------------
+// Test 10: a lone 0xF4 followed by non-magic bytes must NOT commit to a
+// frame. Pre-fix, the parser captured any 0xF4 as a frame start; if the
+// next bytes happened to look like a length+payload, fields could be
+// mis-populated. Post-fix, all four header bytes are validated.
+// ---------------------------------------------------------------------------
+static void test_lone_F4_not_a_header() {
+    std::printf("test_lone_F4_not_a_header ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, false);
+    s.inject({
+        // Lone 0xF4 + three non-magic bytes, then a real frame.
+        0xF4, 0x12, 0x34, 0x56,
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0x0D, 0x00,
+        0x02, 0xAA,
+        0x02, 0x51, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x00, 0x00,
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+    CHECK_EQ((int)r.movingTargetDistance(), 81);
+    CHECK_EQ((int)r.stationaryTargetEnergy(), 59);
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: when a partial header is broken by 0xF4 itself (e.g. radar emits
+// F4 F3 F2 then a stray F4), the parser must reuse the F4 as a fresh
+// position-0, not drop it. This exercises the resync branch where the
+// offending byte is itself a candidate header.
+// ---------------------------------------------------------------------------
+static void test_resync_F4_at_wrong_position() {
+    std::printf("test_resync_F4_at_wrong_position ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, false);
+    s.inject({
+        0xF4, 0xF3, 0xF2,                 // partial header, missing F1
+        0xF4, 0xF3, 0xF2, 0xF1,           // real header (the F4 here is the resync)
+        0x0D, 0x00,
+        0x02, 0xAA,
+        0x02, 0x51, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x00, 0x00,
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+    CHECK_EQ((int)r.movingTargetDistance(), 81);
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: the payload contains the data-frame footer pattern F8 F7 F6 F5
+// in the middle. Pre-fix, the parser called check_frame_end_() after every
+// byte from position 8 onwards and would terminate early when these four
+// bytes appeared in payload, then reject the frame for length mismatch and
+// lose alignment. Post-fix, the footer is only checked at the position
+// dictated by the length field.
+// ---------------------------------------------------------------------------
+static void test_no_early_termination_on_payload_footer() {
+    std::printf("test_no_early_termination_on_payload_footer ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, false);
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0x0D, 0x00,
+        0x02, 0xAA,
+        0x02,                             // target status
+        0xF8, 0xF7,                       // moving distance LE = 0xF7F8 (intra bytes 3..4)
+        0xF6,                             // moving energy = F6 (intra byte 5; getter clamps to 100)
+        0xF5, 0x00,                       // stationary distance LE = 0x00F5
+        0x00,                             // stationary energy
+        0x42, 0x00,                       // detection distance = 0x0042 = 66 (sentinel)
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    // With the old parser, intra-bytes [F8 F7 F6 F5] at positions 9..12 of the
+    // accumulated frame would trigger the per-byte footer check at position 13
+    // and terminate the frame early; parse_data_frame_ would reject and the
+    // detection_distance field (the last field, written only at full parse)
+    // would stay at 0. The sentinel 66 above proves the new parser walked all
+    // 23 bytes before validating the footer.
+    drain(r, s);
+    CHECK_EQ((int)r.movingTargetDistance(), 0xF7F8);
+    CHECK_EQ((int)r.stationaryTargetDistance(), 0x00F5);
+    CHECK_EQ((int)r.detectionDistance(), 66);
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 13: a bogus length field rejects the frame and the parser resyncs in
+// time to capture the next valid frame.
+// ---------------------------------------------------------------------------
+static void test_resync_after_bogus_length() {
+    std::printf("test_resync_after_bogus_length ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, false);
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0xFF, 0xFF,                       // intra length 65535 > LD2410_MAX_FRAME_LENGTH
+        // Parser must drop and look for a fresh header in the bytes that follow.
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0x0D, 0x00,
+        0x02, 0xAA,
+        0x02, 0x51, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x00, 0x00,
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+    CHECK_EQ((int)r.movingTargetDistance(), 81);
+    std::printf("ok\n");
+}
+
 int main() {
     test_basic_frame();
     test_engineering_frame();
@@ -440,6 +556,10 @@ int main() {
     test_command_ack_stale();
     test_command_seq();
     test_command_no_ack();
+    test_lone_F4_not_a_header();
+    test_resync_F4_at_wrong_position();
+    test_no_early_termination_on_payload_footer();
+    test_resync_after_bogus_length();
 
     if (failures == 0) {
         std::printf("\nALL TESTS PASS\n");

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -18,9 +18,22 @@
 #include <cassert>
 #include <initializer_list>
 
+// Mock UART. Two modes:
+//   1. inject(...)            -- bytes are available IMMEDIATELY (used by
+//                                data-frame tests that don't care about
+//                                command/response ordering).
+//   2. inject_response(...)   -- bytes are STAGED and released only when the
+//                                test code observes the radar protocol
+//                                postamble (0x04 0x03 0x02 0x01) being
+//                                written to the UART. This models the real
+//                                radar, which only emits an ACK after it
+//                                has received a complete command.
 class MockSerial : public Stream {
-    std::vector<uint8_t> q_;
+    std::vector<uint8_t> q_;          // bytes available for read()
     size_t pos_ = 0;
+    std::vector<std::vector<uint8_t>> response_queue_;  // staged responses
+    uint8_t last4_[4] = {0};
+    int write_count_ = 0;
 public:
     void inject(std::initializer_list<uint8_t> bytes) {
         q_.insert(q_.end(), bytes.begin(), bytes.end());
@@ -28,12 +41,39 @@ public:
     void inject(const std::vector<uint8_t>& bytes) {
         q_.insert(q_.end(), bytes.begin(), bytes.end());
     }
+    void inject_response(const std::vector<uint8_t>& bytes) {
+        response_queue_.push_back(bytes);
+    }
     int available() override { return (int)(q_.size() - pos_); }
     int read() override {
         if (pos_ >= q_.size()) return -1;
         return q_[pos_++];
     }
-    void clear() { q_.clear(); pos_ = 0; }
+    size_t write(uint8_t b) override {
+        last4_[write_count_ % 4] = b;
+        write_count_++;
+        if (write_count_ >= 4) {
+            // Recover the chronological order of the last 4 writes.
+            uint8_t b0 = last4_[(write_count_ - 4) % 4];
+            uint8_t b1 = last4_[(write_count_ - 3) % 4];
+            uint8_t b2 = last4_[(write_count_ - 2) % 4];
+            uint8_t b3 = last4_[(write_count_ - 1) % 4];
+            if (b0 == 0x04 && b1 == 0x03 && b2 == 0x02 && b3 == 0x01) {
+                if (!response_queue_.empty()) {
+                    const auto& resp = response_queue_.front();
+                    q_.insert(q_.end(), resp.begin(), resp.end());
+                    response_queue_.erase(response_queue_.begin());
+                }
+            }
+        }
+        return 1;
+    }
+    using Print::write;  // pull in the size_t write(const uint8_t*, size_t) overload
+    void clear() {
+        q_.clear(); pos_ = 0;
+        response_queue_.clear();
+        write_count_ = 0;
+    }
 };
 
 static int failures = 0;
@@ -258,12 +298,148 @@ static void test_sequential_frames() {
     std::printf("ok\n");
 }
 
+// ===========================================================================
+// Command-side tests (added by refactor/task-safe-commands).
+// These exercise the wait_for_ack_ + cmd_seq_ machinery via the public
+// request* API. Hardware is not available; we simulate the radar's ACK by
+// pre-loading the MockSerial with the bytes the real radar would send.
+//
+// On the host autoReadTask is not active (no FreeRTOS available), so all
+// commands take the polling branch of wait_for_ack_, which drains UART ->
+// circular buffer -> read_frame_() -> parse_command_frame_() inline.
+// ===========================================================================
+
+// Build a 0xA0 (firmware version) ACK frame with major=1, minor=7, bugfix=0x22091516.
+static std::vector<uint8_t> make_firmware_ack(uint8_t major, uint8_t minor,
+                                              uint8_t b0, uint8_t b1, uint8_t b2, uint8_t b3) {
+    return {
+        0xFD, 0xFC, 0xFB, 0xFA,   // header
+        0x0C, 0x00,               // intra-frame data length = 12
+        0xA0, 0x01,               // command word ACK = 0xA0 | 0x0100 -> LE A0 01
+        0x00, 0x00,               // ACK status: success
+        0x01, 0x00,               // firmware type = 0x0001 LE
+        minor, major,             // bytes 12, 13: minor then major (per parse_command_frame_)
+        b0, b1, b2, b3,           // bugfix uint32 LE
+        0x04, 0x03, 0x02, 0x01    // footer
+    };
+}
+
+// Build a generic short ACK (4-byte payload, status=success) for opcode `op`.
+// Used by enter_configuration_mode_'s ACK (0xFF) and most other commands.
+static std::vector<uint8_t> make_short_ack(uint8_t op, uint16_t intra_len = 4) {
+    std::vector<uint8_t> v = {
+        0xFD, 0xFC, 0xFB, 0xFA,
+        (uint8_t)(intra_len & 0xFF), (uint8_t)((intra_len >> 8) & 0xFF),
+        op, 0x01,                // command word ACK
+        0x00, 0x00               // status: success
+    };
+    // Pad with zero bytes if the caller asked for a longer intra_len so
+    // length matches what the radar would actually send for some commands.
+    for (uint16_t i = 4; i < intra_len; i++) v.push_back(0x00);
+    v.push_back(0x04); v.push_back(0x03); v.push_back(0x02); v.push_back(0x01);
+    return v;
+}
+
+// Test: requestFirmwareVersion full flow.
+// Inject ACKs in the order the real radar would send: enter-config (0xFF),
+// firmware-version (0xA0), leave-config (0xFE). All three must succeed and
+// firmware_*_version fields must be populated.
+static void test_command_ack_polling() {
+    std::printf("test_command_ack_polling ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+
+    // enter_configuration_mode_ -> ACK 0xFF with 8-byte payload (status + version + buffer)
+    // Stage three responses: each is released when the radar postamble is
+    // written (i.e. immediately after the corresponding command bytes go out).
+    s.inject_response(make_short_ack(0xFF, 8));
+    s.inject_response(make_firmware_ack(1, 7, 0x16, 0x15, 0x09, 0x22));
+    s.inject_response(make_short_ack(0xFE, 4));
+
+    bool ok = r.requestFirmwareVersion();
+    CHECK(ok);
+    CHECK_EQ((int)r.firmware_major_version, 1);
+    CHECK_EQ((int)r.firmware_minor_version, 7);
+    CHECK_EQ((unsigned long)r.firmware_bugfix_version, 0x22091516UL);
+    CHECK(!r.isAutoReadTaskRunning());
+    std::printf("ok\n");
+}
+
+// Test: ACK with wrong opcode -> command must time out, returns false.
+// Inject only enter-config ACK; the firmware command then receives no
+// matching ACK and wait_for_ack_ should give up at radar_uart_command_timeout_.
+static void test_command_ack_stale() {
+    std::printf("test_command_ack_stale ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+    // Only enter-config ACK; nothing for the actual command. wait_for_ack_
+    // for 0xA0 will time out (radar_uart_command_timeout_ = 100 ms).
+    s.inject_response(make_short_ack(0xFF, 8));
+
+    // requestFirmwareVersion will: enter (ok), send 0xA0, then wait for 0xA0
+    // ACK that never arrives. Should return false.
+    bool ok = r.requestFirmwareVersion();
+    CHECK(!ok);
+    std::printf("ok\n");
+}
+
+// Test: two requestFirmwareVersion calls back-to-back. The cmd_seq_ counter
+// must invalidate any leftover ACK state from call #1 so call #2 doesn't
+// short-circuit on the previous response. We also vary the firmware bytes
+// between the two calls to confirm the second value is what we read.
+static void test_command_seq() {
+    std::printf("test_command_seq ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+
+    // Call #1: major=1, minor=7
+    s.inject_response(make_short_ack(0xFF, 8));
+    s.inject_response(make_firmware_ack(1, 7, 0x16, 0x15, 0x09, 0x22));
+    s.inject_response(make_short_ack(0xFE, 4));
+    CHECK(r.requestFirmwareVersion());
+    CHECK_EQ((int)r.firmware_major_version, 1);
+
+    // Call #2: major=2, minor=10. Different bytes prove we are reading
+    // the SECOND ACK not a residual from the first.
+    s.inject_response(make_short_ack(0xFF, 8));
+    s.inject_response(make_firmware_ack(2, 10, 0x01, 0x02, 0x03, 0x04));
+    s.inject_response(make_short_ack(0xFE, 4));
+    CHECK(r.requestFirmwareVersion());
+    CHECK_EQ((int)r.firmware_major_version, 2);
+    CHECK_EQ((int)r.firmware_minor_version, 10);
+    CHECK_EQ((unsigned long)r.firmware_bugfix_version, 0x04030201UL);
+    std::printf("ok\n");
+}
+
+// Test: completely silent UART -> command must time out cleanly (no
+// infinite loop, no field corruption).
+static void test_command_no_ack() {
+    std::printf("test_command_no_ack ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+    // s is empty: no ACK at all.
+    bool ok = r.requestFirmwareVersion();
+    CHECK(!ok);
+    // Fields must remain at their initial zero values.
+    CHECK_EQ((int)r.firmware_major_version, 0);
+    CHECK_EQ((int)r.firmware_minor_version, 0);
+    std::printf("ok\n");
+}
+
 int main() {
     test_basic_frame();
     test_engineering_frame();
     test_invalid_data_type();
     test_invalid_trailer();
     test_sequential_frames();
+    test_command_ack_polling();
+    test_command_ack_stale();
+    test_command_seq();
+    test_command_no_ack();
 
     if (failures == 0) {
         std::printf("\nALL TESTS PASS\n");

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,0 +1,274 @@
+// Native host-side unit test for ld2410::parse_data_frame_().
+// Feeds known-good frames (from the HLK-LD2410C V1.00 protocol document
+// in docs/HLK-LD2410C_protocol.md) through the public read() API via a
+// mock Stream, and asserts that the resulting field values match the
+// protocol specification.
+//
+// Build & run:  bash tests/run.sh   (from the repo root)
+//
+// On the host ESP32 is not defined, so the FreeRTOS task path and the
+// portMUX critical sections are compiled out. The test exercises only
+// the parser, which is the surface this branch actually changed.
+
+#include <Arduino.h>
+#include <ld2410.h>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+#include <cassert>
+#include <initializer_list>
+
+class MockSerial : public Stream {
+    std::vector<uint8_t> q_;
+    size_t pos_ = 0;
+public:
+    void inject(std::initializer_list<uint8_t> bytes) {
+        q_.insert(q_.end(), bytes.begin(), bytes.end());
+    }
+    void inject(const std::vector<uint8_t>& bytes) {
+        q_.insert(q_.end(), bytes.begin(), bytes.end());
+    }
+    int available() override { return (int)(q_.size() - pos_); }
+    int read() override {
+        if (pos_ >= q_.size()) return -1;
+        return q_[pos_++];
+    }
+    void clear() { q_.clear(); pos_ = 0; }
+};
+
+static int failures = 0;
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        std::fprintf(stderr, "FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+        failures++; \
+    } \
+} while (0)
+
+#define CHECK_EQ(a, b) do { \
+    auto _a = (a); auto _b = (b); \
+    if (!(_a == _b)) { \
+        std::fprintf(stderr, "FAIL %s:%d  %s == %s : got %lld vs %lld\n", \
+                     __FILE__, __LINE__, #a, #b, (long long)_a, (long long)_b); \
+        failures++; \
+    } \
+} while (0)
+
+// Helper: pump the parser by calling read() until all queued bytes are drained.
+static void drain(ld2410& r, MockSerial& s) {
+    while (s.available() > 0) {
+        r.read();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: basic frame from protocol §2.3.2 (Table 12 example).
+//   F4 F3 F2 F1 | 0D 00 | 02 AA 02 51 00 00 00 00 3B 00 00 55 00 | F8 F7 F6 F5
+// Decoded:
+//   data_type=0x02 (basic), target_status=0x02,
+//   moving distance=0x0051=81 cm, moving energy=0,
+//   stationary distance=0, stationary energy=0x3B=59,
+//   detection distance=0
+// ---------------------------------------------------------------------------
+static void test_basic_frame() {
+    std::printf("test_basic_frame ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1,             // header
+        0x0D, 0x00,                         // intra-frame data length = 13
+        0x02, 0xAA,                         // data_type basic, head 0xAA
+        0x02,                               // target status
+        0x51, 0x00,                         // moving distance LE = 81
+        0x00,                               // moving energy
+        0x00, 0x00,                         // stationary distance = 0
+        0x3B,                               // stationary energy = 59
+        0x00, 0x00,                         // detection distance = 0
+        0x55, 0x00,                         // tail + calibration
+        0xF8, 0xF7, 0xF6, 0xF5              // footer
+    });
+    drain(r, s);
+
+    CHECK(r.presenceDetected());                     // target_status != 0
+    CHECK(!r.movingTargetDetected());                // moving energy 0 -> not detected
+    // Note: r.stationaryTargetDetected() is intentionally NOT asserted.
+    // The doc's contrived basic-frame example has stationary_distance=0,
+    // and the helper requires both distance > 0 and energy > 0. Parser is
+    // correct; the doc example is just synthetic. We assert raw fields.
+    CHECK_EQ((int)r.movingTargetDistance(), 81);
+    CHECK_EQ((int)r.movingTargetEnergy(), 0);
+    CHECK_EQ((int)r.stationaryTargetDistance(), 0);
+    CHECK_EQ((int)r.stationaryTargetEnergy(), 59);
+    CHECK_EQ((int)r.detectionDistance(), 0);
+    CHECK(!r.engineeringRetrieved());                // no eng frame yet
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: engineering frame from protocol §2.3.2 (Table 14 example).
+//   F4 F3 F2 F1 | 23 00 | 01 AA 03 1E 00 3C 00 00 39 00 00
+//                          08 08
+//                          3C 22 05 03 03 04 03 06 05
+//                          00 00 39 10 13 06 06 08 04
+//                          03 05    (retain bytes)
+//                          55 00 |
+//   F8 F7 F6 F5
+// Decoded: target_status=0x03, moving=30 cm @ 60, stationary=0 @ 57,
+//   detection=0; per-gate motion energies = [60, 34, 5, 3, 3, 4, 3, 6, 5];
+//   per-gate stationary energies = [0, 0, 57, 16, 19, 6, 6, 8, 4].
+// Pre-fix: the strict 0x02 check rejected this frame and the buffer-size
+// guard (LD2410_MAX_FRAME_LENGTH=40) would have dropped it before parsing.
+// ---------------------------------------------------------------------------
+static void test_engineering_frame() {
+    std::printf("test_engineering_frame ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0x23, 0x00,                                // intra length = 35
+        0x01, 0xAA,                                // engineering, head
+        0x03,                                      // target status: both
+        0x1E, 0x00,                                // moving dist = 30
+        0x3C,                                      // moving energy = 60
+        0x00, 0x00,                                // stationary dist = 0
+        0x39,                                      // stationary energy = 57
+        0x00, 0x00,                                // detection dist = 0
+        0x08, 0x08,                                // max moving N=8, max stationary N=8
+        0x3C, 0x22, 0x05, 0x03, 0x03, 0x04, 0x03, 0x06, 0x05,  // motion gate 0..8
+        0x00, 0x00, 0x39, 0x10, 0x13, 0x06, 0x06, 0x08, 0x04,  // stationary gate 0..8
+        0x03, 0x05,                                // retain (M=2)
+        0x55, 0x00,                                // tail + cal at idx 39, 40
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+
+    CHECK_EQ((int)r.movingTargetDistance(), 30);
+    CHECK_EQ((int)r.movingTargetEnergy(), 60);
+    CHECK_EQ((int)r.stationaryTargetDistance(), 0);
+    CHECK_EQ((int)r.stationaryTargetEnergy(), 57);
+    CHECK_EQ((int)r.detectionDistance(), 0);
+
+    // Per-gate energies: this is the new surface that pre-fix did not exist.
+    int expected_motion[9]     = {60, 34,  5,  3,  3,  4,  3,  6,  5};
+    int expected_stationary[9] = { 0,  0, 57, 16, 19,  6,  6,  8,  4};
+    for (uint8_t g = 0; g < 9; g++) {
+        CHECK_EQ((int)r.movingEnergyAtGate(g), expected_motion[g]);
+        CHECK_EQ((int)r.stationaryEnergyAtGate(g), expected_stationary[g]);
+    }
+    // Out-of-range gate index must return 0, not out-of-bounds-read.
+    CHECK_EQ((int)r.movingEnergyAtGate(9), 0);
+    CHECK_EQ((int)r.stationaryEnergyAtGate(255), 0);
+
+    CHECK(r.engineeringRetrieved());
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: malformed frame (bad data_type) must be rejected.
+// Same length as a basic frame but data_type = 0x99 (neither 0x01 nor 0x02).
+// ---------------------------------------------------------------------------
+static void test_invalid_data_type() {
+    std::printf("test_invalid_data_type ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0x0D, 0x00,
+        0x99, 0xAA,                                // INVALID data_type
+        0x02, 0x51, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x00, 0x00,
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+
+    // Fields must remain at their initial zero values - no spurious update.
+    CHECK_EQ((int)r.movingTargetDistance(), 0);
+    CHECK_EQ((int)r.stationaryTargetEnergy(), 0);
+    CHECK_EQ((int)r.detectionDistance(), 0);
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: bad trailer byte must be rejected (anchor on dynamic position).
+// Use a basic frame but corrupt the 0x55 tail.
+// ---------------------------------------------------------------------------
+static void test_invalid_trailer() {
+    std::printf("test_invalid_trailer ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1,
+        0x0D, 0x00,
+        0x02, 0xAA,
+        0x02, 0x51, 0x00, 0x00, 0x00, 0x00, 0x3B, 0x00, 0x00,
+        0x77, 0x00,                                // bogus tail (must be 0x55 0x00)
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+
+    CHECK_EQ((int)r.movingTargetDistance(), 0);    // not updated
+    std::printf("ok\n");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: two consecutive frames - basic then engineering - should reuse
+// the same library instance correctly and reflect the latest values.
+// ---------------------------------------------------------------------------
+static void test_sequential_frames() {
+    std::printf("test_sequential_frames ... ");
+    ld2410 r;
+    MockSerial s;
+    r.begin(s, /*waitForRadar=*/false);
+
+    // First: a basic frame with moving distance 100 cm
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1, 0x0D, 0x00,
+        0x02, 0xAA, 0x01, 0x64, 0x00, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+    CHECK_EQ((int)r.movingTargetDistance(), 100);
+    CHECK_EQ((int)r.movingTargetEnergy(), 50);
+    CHECK(!r.engineeringRetrieved());
+
+    // Then: engineering frame, moving distance 200, gate 5 motion energy 42
+    s.inject({
+        0xF4, 0xF3, 0xF2, 0xF1, 0x23, 0x00,
+        0x01, 0xAA, 0x01,
+        0xC8, 0x00,                                // moving dist = 200
+        0x14,                                      // moving energy = 20
+        0x00, 0x00, 0x00, 0x00, 0x00,              // stationary + detection
+        0x08, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x2A, 0x00, 0x00, 0x00,  // gate 5 motion = 0x2A=42
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00,
+        0x55, 0x00,
+        0xF8, 0xF7, 0xF6, 0xF5
+    });
+    drain(r, s);
+    CHECK_EQ((int)r.movingTargetDistance(), 200);
+    CHECK_EQ((int)r.movingTargetEnergy(), 20);
+    CHECK_EQ((int)r.movingEnergyAtGate(5), 42);
+    CHECK(r.engineeringRetrieved());
+    std::printf("ok\n");
+}
+
+int main() {
+    test_basic_frame();
+    test_engineering_frame();
+    test_invalid_data_type();
+    test_invalid_trailer();
+    test_sequential_frames();
+
+    if (failures == 0) {
+        std::printf("\nALL TESTS PASS\n");
+        return 0;
+    }
+    std::printf("\n%d FAILURE(S)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
  Hi! This PR consolidates work from the [`adapt-to-it/ld2410`](https://github.com/adapt-to-it/ld2410) fork that has been developed and validated on real hardware (ESP32 + LD2410C, firmware `2.4.23022511`) over
  multiple iterations. Each individual change was reviewed and merged into the fork's `main` separately; the cumulative diff is what you see here. Happy to split into smaller PRs or rebase as you prefer — just
  let me know.

  The protocol references throughout point to a curated copy of the HLK-LD2410C V1.00 protocol document (`docs/HLK-LD2410C_protocol.md`, also added in this PR) so all byte-level decisions are traceable to a
  written spec.

  ## What's in this PR

  ### 1. Cross-platform polling-path fixes (`src/ld2410.cpp`, `src/ld2410.h`)
  The polling `read()` path used to reach for FreeRTOS / ESP32-only constructs unconditionally, which broke compilation on AVR and ESP8266 in some configurations. Those constructs are now properly gated behind
  `#if defined(ESP32)` so AVR (Leonardo), ESP8266 (NodeMCU/Wemos D1 mini), and ESP32 all compile cleanly from the same source.

  ### 2. Protocol-aligned engineering frame parser (`src/ld2410.cpp`)
  - Engineering frames (data type `0x01`) were not being decoded; the parser only accepted `0x02` basic frames.
  - Per-gate motion / stationary energies are now extracted at the offsets defined in **Table 14** of the protocol (`frame[19..27]` and `frame[28..36]`), with public accessors `movingEnergyAtGate(gate)` and
  `stationaryEnergyAtGate(gate)`.
  - `engineeringRetrieved()` getter signals whether at least one engineering-mode frame has been parsed.

  ### 3. Length-driven frame state machine (parser hardening)
  The previous parser had two latent issues:
  - Committed to a frame after seeing a single `0xF4` / `0xFD` byte. A 0xF4 byte appears in many legitimate radar payloads (low byte of a 244 cm distance, or anywhere after a UART overrun at 256 kbaud), and the
  parser would then read fields from the wrong offsets.
  - Tested the footer pattern (`F8 F7 F6 F5`) after every byte from position 8 onward. When intra-frame data happened to spell those four bytes, the frame terminated early; `parse_data_frame_` rejected it for
  length mismatch and the *real* footer of that frame stayed in the buffer to seed the next "frame start" — a tail-of-one-frame-as-head-of-another desync.

  The new parser validates all four magic-header bytes (with intelligent resync if the offending byte is itself `0xF4`/`0xFD`), captures the length once at position 5, accumulates exactly `intra_len + 10` bytes,
  and validates the footer once at the known offset. Same public API.

  This pass also strips dead state that had accumulated:
  - File-scope globals `circular_buffer / buffer_head / buffer_tail` that shadowed the class members and were unreachable.
  - An unused `frame_buffer[1024] / current_state / frame_position / frame_length` set that looked like a half-implemented alternate parser. Net **-1280 bytes** of BSS.
  - `find_frame_start()` was defined but never called.
  - `frame_started_` member, redundant with `radar_data_frame_position_ == 0`.

  ### 4. Task-safe `request*` / `set*` commands (ESP32)
  With the optional `autoReadTask()` running, the existing blocking command path raced the task on `radar_uart_->read()` and on the ACK-flag fields, producing intermittent timeouts and corrupted data frames.

  The fix introduces a small synchronization triplet (`cmd_seq_`, `cmd_ack_seq_`, `expected_ack_opcode_`) protected by a `portMUX_TYPE`, plus a `wait_for_ack_(opcode, timeout)` helper that picks the right
  strategy at runtime: when the task is running it polls `cmd_ack_seq_`; otherwise it drives the UART directly. All ten existing `request*` / `set*` helpers were migrated to this path; semantics and signatures
  are unchanged.

  `requestRestart()` additionally suspends the task for the radar's ~800 ms reboot blackout so the post-reset garbage doesn't end up in the parser.

  ### 5. Optional `autoReadTask()` background reader (ESP32)
  A FreeRTOS task that drains the radar UART continuously, so consumer code never has to call `radar.read()` and never blocks on UART. Demonstrated in the new `examples/autoReadTask/autoReadTask.ino`. Available
  on ESP32 only — gated by `#if defined(ESP32)` and surfaced via a runtime `isAutoReadTaskRunning()` getter so consumer code can branch without compile-time `#if`s.

  ### 6. Engineering-mode helpers wrapped in enter/leave configuration
  `requestStartEngineeringMode()` and `requestEndEngineeringMode()` were issuing `0x0062` / `0x0063` directly without first opening a configuration window. Per protocol §2.4.1 every config command must be sent
  inside an `enter_configuration_mode_()` / `leave_configuration_mode_()` window — the radar silently rejects commands sent outside one. Both helpers now wrap exactly like the other config commands; reproduced
  and confirmed on hardware (engineering frames now stream as expected).

  ### 7. New ESP8266 example
  `examples/basicSensorEsp8266/basicSensorEsp8266.ino` — uses `SoftwareSerial` because the ESP8266's hardware UART layout (one full UART + one TX-only UART, with `Serial.swap()` colliding with strapping pin
  GPIO15 when the radar TX idles HIGH) makes a hardware-UART example impractical. The header documents the trade-off (SoftwareSerial @ 256000 baud is at the upper edge of EspSoftwareSerial's reliable range). The
  pre-existing `examples/basicSensor.ino` comment was updated to point at this sibling instead of stating no ESP8266 example exists.

  ### 8. Native host-side parser unit tests
  `tests/test_parser.cpp` builds with plain `g++` against a minimal `tests/Arduino.h` Stream/Print stub. 13 tests covering:
  - Basic frame from protocol §2.3.2 (Table 12 example)
  - Engineering frame from §2.3.2 (Table 14 example)
  - Malformed data type rejection
  - Bad trailer rejection
  - Sequential frames (basic → engineering)
  - Command-side: ACK polling, stale-ACK rejection, sequence counter, timeout
  - Resync: lone `F4` not a header, `F4` mid-header, `F8 F7 F6 F5` inside payload, bogus length

  Run with `bash tests/run.sh` from the repo root.

  ### 9. `keywords.txt` and `.gitignore`
  - `keywords.txt`: added `getFrameData`, `detectionDistance`, `movingEnergyAtGate`, `stationaryEnergyAtGate`, `engineeringRetrieved`, `autoReadTask`, `stopAutoReadTask`, `isAutoReadTaskRunning`. Fixed missing
  `KEYWORD2` tags on a couple of pre-existing entries.
  - `.gitignore`: added `tests/test_parser` build artifact.

  ## Verification

  - [x] `bash tests/run.sh` → 13/13 `ALL TESTS PASS`
  - [x] `arduino-cli compile --fqbn esp32:esp32:esp32 examples/basicSensor` → 21% flash, 6% RAM
  - [x] `arduino-cli compile --fqbn esp32:esp32:esp32 examples/autoReadTask` → 22% flash
  - [x] `arduino-cli compile --fqbn esp8266:esp8266:nodemcuv2 examples/basicSensorEsp8266` → 23% flash
  - [x] Hardware: ESP32 + real LD2410C — firmware version parsed, `autoReadTask` streams data frames continuously, blocking commands issued under the running task return `true`, engineering mode enables and
  per-gate energies populate matching the protocol Table 14 layout

  ## Notes for review

  - The protocol document (`docs/HLK-LD2410C_protocol.md`) is added in the same PR because the new tests cite it for fixture frames. If you'd rather not vendor it, I can move it to a separate PR or drop it.
  - Several of these changes are independent of one another — happy to split into smaller PRs (cross-platform fix, parser fixes, autoReadTask, host tests, ESP8266 example, engineering-mode wrap) if that's easier
  to review.
  - Original PRs in the fork (with individual review history): [#1](https://github.com/adapt-to-it/ld2410/pull/1), [#2](https://github.com/adapt-to-it/ld2410/pull/2),
  [#3](https://github.com/adapt-to-it/ld2410/pull/3), [#4](https://github.com/adapt-to-it/ld2410/pull/4), [#6](https://github.com/adapt-to-it/ld2410/pull/6), [#7](https://github.com/adapt-to-it/ld2410/pull/7).

  Thank you for maintaining this library — happy to iterate on any of this based on your feedback.