### PR TITLE
chore(release): bump version to 0.2.1 for Library Manager pickup

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ld2410
-version=0.1.4
+version=0.2.1
 author=Nick Reynolds
 maintainer=Nick Reynolds <ncmreynolds+ld2410@googlemail.com>
 sentence=An Arduino library for the Hi-Link LD2410 24Ghz FMCW radar sensor.


### PR DESCRIPTION
The v0.2.0 tag (merge of PR #43) ships with library.properties still pinned at version=0.1.4. The Arduino Library Manager indexer requires the library.properties version field to match the new tag; on a mismatch it falls back to treating the release as the previously indexed version. As a result no user receives an update notification in Arduino IDE -- "0.1.4 INSTALLED" stays shown indefinitely even though v0.2.0 source is available on GitHub.

Bump to 0.2.1 (skipping a re-cut of 0.2.0, whose tag is already public and shouldn't be force-moved) so a fresh tag + Release lets the Library Manager finally advertise the parser/engineering/task API additions from PR #43.