### PR TITLE
fix(parser): ESP8266 unaligned-load crash + release 0.2.2

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ld2410
-version=0.2.1
+version=0.2.2
 author=Nick Reynolds
 maintainer=Nick Reynolds <ncmreynolds+ld2410@googlemail.com>
 sentence=An Arduino library for the Hi-Link LD2410 24Ghz FMCW radar sensor.

--- a/src/ld2410.cpp
+++ b/src/ld2410.cpp
@@ -450,11 +450,16 @@ bool ld2410::parse_data_frame_() {
     portENTER_CRITICAL(&data_mux_);
 #endif
     target_type_ = radar_data_frame_[8];
-    moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
+    // ESP8266 (Xtensa LX106) faults on 16-bit loads from odd addresses, and
+    // offsets 9 and 15 are odd. memcpy compiles to a single unaligned load on
+    // targets that support it (ESP32 / ARM / x86) and to byte loads on those
+    // that don't, so one form works everywhere. LD2410 payloads are little-
+    // endian, matching every supported Arduino target.
+    memcpy(&moving_target_distance_,     &radar_data_frame_[9],  sizeof(uint16_t));
     moving_target_energy_ = radar_data_frame_[11];
-    stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[12]);
+    memcpy(&stationary_target_distance_, &radar_data_frame_[12], sizeof(uint16_t));
     stationary_target_energy_ = radar_data_frame_[14];
-    detection_distance_ = *(uint16_t*)(&radar_data_frame_[15]);
+    memcpy(&detection_distance_,         &radar_data_frame_[15], sizeof(uint16_t));
 
     // Tabella 14: extra engineering. Layout (full-frame index, 0-based):
     //   17 = max moving gate N (ridondante con max_moving_gate da requestCurrentConfiguration)


### PR DESCRIPTION
## Summary

- **Fix**: `parse_data_frame_()` read three `uint16_t` fields with `*(uint16_t*)(&buf[N])` at odd offsets (9 and 15), which is double-UB: strict-aliasing violation + unaligned 16-bit load. On ESP8266 (Xtensa LX106) there is no hardware handler for unaligned loads, so the first basic data frame parsed in `loop()` traps the CPU and reboots the chip. ESP32 (LX6) hid the bug because it has the unaligned-access exception simulator.
- **Symptom reported by users**: sketch starts, publishes first MQTT message, then reboots before the second `loop()` iteration completes — matches exactly the timing of the first valid data frame reaching the parser.
- **Fix shape**: replace the three casts with `memcpy(&dst, &buf[N], sizeof(uint16_t))`. GCC compiles this into a single unaligned half-word load on targets that support it (ESP32 / ARM / x86) and byte loads where they don't (ESP8266 / AVR) — one form, portable, zero overhead. LD2410 payload is little-endian on all supported Arduino targets.
- **Release 0.2.2**: `library.properties` bumped so the fix reaches users via the Arduino Library Manager. v0.2.1 is already live and carries the regression.

## Files

- `src/ld2410.cpp` — 3 cast sites swapped for `memcpy` in `parse_data_frame_()`.
- `library.properties` — `version=0.2.1` → `version=0.2.2`.

## Test plan

- [x] Host parser unit tests: `bash tests/run.sh` → 13/13 PASS.
- [ ] Field validation: confirm sketch that crashed on v0.2.1 + ESP8266 stays up across `loop()` iterations with this branch.
- [ ] Verify ESP32 behaviour unchanged (no regression in the `portMUX`-guarded update path).
